### PR TITLE
Implement HTTP/1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,53 @@ A version number says how stable the scripting API is — the library functions 
 must not be exposed on Internet, at 1.0 as at 0.1 (see
 [About security](./README.md#about-security)).
 
+1.1 — 2026-08-21
+----------------
+
+Sherver speaks HTTP/1.1 now, and behaves like it: the request line and the `Host` header are
+validated, `OPTIONS` is answered, and a file can be served by byte range — which is what makes
+`<video>` seeking work. Nothing was removed from the scripting API.
+
+- **answers in HTTP/1.1**, to a 1.0 client as well (RFC 9112 §2.3 — the version in the response
+  says what the server can do, not what the request was). `REQUEST_HTTP_VERSION` is validated
+  instead of merely parsed: anything that is not `HTTP/1.x` is a `400`, another major version a
+  `505`
+- **`Host` is mandatory** on an HTTP/1.1 request, missing it is a `400`. An HTTP/1.0 request
+  without `Host` stays legal
+- **byte ranges**: every file answer announces `Accept-Ranges: bytes`, and a GET carrying a single
+  `Range: bytes=…` gets a `206` with its `Content-Range`. A range starting past the end of the file
+  is a `416`; a stale `If-Range`, several ranges, another unit or plain garbage are ignored and the
+  whole file is served, never an error
+- **`OPTIONS`**, answered by the dispatcher for any target, `*` included, with `Allow` and an empty
+  body. `PUT`, `DELETE`, `PATCH`, `TRACE` and `CONNECT` still get a `405`, which now carries `Allow`
+  as RFC 9110 §15.5.6 requires — **do the same before your own `send_error 405`**. A method that is
+  none of those gets a `501` instead of a `405`
+- **absolute-form request target**: `GET http://host/path HTTP/1.1` is accepted, as RFC 9112 §3.2.2
+  requires of a server. Scripts see the rewritten path in `REQUEST_URL`, and the authority in the
+  target replaces whatever `Host` the client sent
+- **an error is never stored**: `send_error` answers `Cache-Control: no-store` and drops any `ETag` and
+  `Last-Modified` already set
+- **no more `Expires`**: `Cache-Control` is the only freshness field now. A cache must ignore `Expires`
+  whenever `max-age` is there (RFC 9111 §5.3), and the one Sherver sent carried the `Date` itself, so
+  it could only contradict the `private, max-age=60` next to it. `add_header 'Expires' …` still puts
+  it back on an answer of your own
+- `HTTP_RESPONSE` gains the codes that go with all this: `206`, `416`, `501`, `505`
+- `tail` and `head` join the external commands, for range answers only — busybox's are enough
+- add support for redirections 301/302
+- add support for `Last-Modified` header
+- add IP in logs
+
+Deliberately left out, and worth knowing about:
+
+- **no keep alive**, and none planned: `Connection: close` on every response is a compliant opt-out
+  (RFC 9112 §9.6), and one process per connection is the whole architecture
+- a **chunked request body** is read as no body at all, where it should get a `411`. No common
+  client sends one unprompted
+- **`Expect: 100-continue`** is not answered: a client that waits for the interim response eats
+  socat's timeout and sends anyway
+- the **header parser is still naive**: a line without a colon, whitespace before the colon, a
+  folded line, a duplicated `Host` or `Content-Length` — none of them are rejected
+
 1.0 — 2026-08-14
 ----------------
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,8 @@ version and exits; [CHANGELOG.md](./CHANGELOG.md) says what each one brought.
 This is made to run with `Bash`. It may not work in another shell. The following tools need to be present in the system (note that they are all part of the default installation of Debian):
 - `socat` to run the server.
 	- you can use `netcat` instead, but it doesn't work well with concurrent HTTP requests
-- `date`, `realpath`, `stat` and `cat` — from `coreutils` on a GNU system, but busybox's versions are enough (see below)
+- `date`, `realpath`, `stat`, `cat` and — to answer a byte range — `tail` and `head`: from `coreutils`
+	on a GNU system, but busybox's versions are enough (see below)
 - optionnal: `envsubst` if you want to do templating (comes in the package `gettext-base` in Debian, or something like `gettext-envsubst` as a smaller package in Alpine)
 - for development: `bats` and `shellcheck` for the tests. The two suites that open a port also want
 	`curl`, and the HTTPS one uses `openssl` to generate itself a throwaway certificate, falling back on
@@ -77,22 +78,25 @@ This is made to run with `Bash`. It may not work in another shell. The following
 [docs/call-graph.md#external-commands](./docs/call-graph.md#external-commands) lists which function calls which of
 these tools.
 
-On a busybox system such as an Alpine container, `coreutils` is not needed: `date -uR`, `stat -c` and
-`cat` are all covered by busybox, and `realpath` is called without any option precisely so that
-busybox's — which parses none — is enough. Only `bash`, `socat` and — because the default index page
-templates itself with it — `envsubst` have to come from packages.
+On a busybox system such as an Alpine container, `coreutils` is not needed: `date -uR`, `stat -c`,
+`cat` and the `tail -c +N | head -c N` of a range answer are all covered by busybox, and `realpath` is
+called without any option precisely so that busybox's — which parses none — is enough. Only `bash`,
+`socat` and — because the default index page templates itself with it — `envsubst` have to come from
+packages.
 
 ### Features ###
 
-Sherver is a web server that implements part of HTTP 1.0. Even if it is written in a few lines of Bash, it is able to do a lot:
+Sherver is a web server that implements part of HTTP 1.1. Even if it is written in a few lines of Bash, it is able to do a lot:
 - no configuration needed: you can just add files either in `scripts` or in `file` folders
 - serve any HTML page no matter how complexe (with advanced JavaScript and multiple scripts or files to download...)
 - serve files (text or binary, pictures...) with correct mime type
 - dynamic pages
 - templated HTML so you don't have to duplicate headers and footers
-- parse of URL query string, percent decoded (so `/file/my%20file.txt` finds `my file.txt`)
+- parse of URL query string, percent decoded (so `/file/my%20file.txt` finds `my file.txt`), in
+  origin form as in absolute form (`GET http://host/path HTTP/1.1`)
 - support for GET, HEAD, POST and OPTIONS
 - deal with client cache resources
+- serve a file by byte range, so a `<video>` can be seeked in (and plays at all in Safari)
 - easily extandable
 	- can run any scripts or executable of any languages as soon as they output something on `stdout`
 	- comes with a library of bash functions to ease the use
@@ -105,10 +109,17 @@ Even if it sounds awesome, Sherver still has the following limitations:
   anything else a `501`
 - concurrency is capped at 32 connections: `socat` forks one process per connection and makes the
   next ones wait for a free slot, so a burst queues instead of thrashing the machine
-- no keep alive: this is HTTP 1.0 with `Connection: close`, so one request per connection
+- no keep alive, and none planned: every response carries `Connection: close`, so it is one request
+  per connection. RFC 9112 §9.6 makes that a compliant way out of persistent connections, and it is
+  what lets `socat` fork one short-lived process per connection with nothing shared between them
 - no shared state between requests: each one is a brand new process, so nothing is cached server side
 - POST bodies are limited to 64 kio, bigger ones get a `413` answer (see [POST requests](#post-requests))
 - the request line and headers are limited to 8 kio, bigger ones get a `414` or a `431` answer
+- a chunked request body is read as no body at all, where it should get a `411`, and
+  `Expect: 100-continue` is not answered — a client that waits for it eats socat's timeout and sends
+  anyway. No common client does either unprompted
+- the header parser is naive: a line without a colon, whitespace before the colon, a folded line, a
+  duplicated `Host` or `Content-Length` are all accepted where the RFC asks for a `400`
 - no security (see [About Security](#about-security)).
 
 This is why Sherver is supposed to remain in a private and controlled environment. **Do not expose Sherver on Internet!!!** If you want to expose your site on Internet, you should use a tool that knows about security and scalability (like *nginx* or other).

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Sherver is a web server that implements part of HTTP 1.0. Even if it is written 
 - dynamic pages
 - templated HTML so you don't have to duplicate headers and footers
 - parse of URL query string, percent decoded (so `/file/my%20file.txt` finds `my file.txt`)
-- support for GET, HEAD and POST
+- support for GET, HEAD, POST and OPTIONS
 - deal with client cache resources
 - easily extandable
 	- can run any scripts or executable of any languages as soon as they output something on `stdout`
@@ -100,7 +100,9 @@ Sherver is a web server that implements part of HTTP 1.0. Even if it is written 
 All of these makes Sherver the perfect tool to run a small server that will serve few pages on your local network.
 
 Even if it sounds awesome, Sherver still has the following limitations:
-- only support HTTP GET, HEAD and POST requests, though it would be easy to add the others
+- only support HTTP GET, HEAD, POST and OPTIONS requests, though it would be easy to add the others:
+  `PUT`, `DELETE`, `PATCH`, `TRACE` and `CONNECT` get a `405` carrying an `Allow` header, and
+  anything else a `501`
 - concurrency is capped at 32 connections: `socat` forks one process per connection and makes the
   next ones wait for a free slot, so a burst queues instead of thrashing the machine
 - no keep alive: this is HTTP 1.0 with `Connection: close`, so one request per connection
@@ -214,7 +216,9 @@ the requests in a text format:
 #!/bin/bash
 
 init_environment
+# `OPTIONS` is advertised but not tested: the dispatcher answers it before routing
 if [ "$REQUEST_METHOD" != 'GET' ] && [ "$REQUEST_METHOD" != 'HEAD' ]; then
+	add_header 'Allow' 'GET, HEAD, OPTIONS'
 	send_error 405
 fi
 
@@ -253,7 +257,9 @@ And you would use it with the following script:
 #!/bin/bash
 
 init_environment
+# `OPTIONS` is advertised but not tested: the dispatcher answers it before routing
 if [ "$REQUEST_METHOD" != 'GET' ] && [ "$REQUEST_METHOD" != 'HEAD' ]; then
+	add_header 'Allow' 'GET, HEAD, OPTIONS'
 	send_error 405
 fi
 

--- a/dispatcher.sh
+++ b/dispatcher.sh
@@ -23,8 +23,15 @@ source 'scripts/SHERVER_UTILS.sh'
 
 init_environment
 
+# answer OPTIONS for the whole server, before any path resolution: that is what makes the
+# asterisk-form `OPTIONS * HTTP/1.1` work, as `*` is no path and would only ever 404
+if [ "$REQUEST_METHOD" = 'OPTIONS' ]; then
+	add_header 'Allow' "$SUPPORTED_METHODS"
+	# 200 with an empty body and not 204: a 204 MUST NOT carry the `Content-Length`
+	# that `send_response` adds to everything but a 304
+	send_response 200
 # serve file
-if [[ $URL_BASE =~ ^/file/.* ]]; then
+elif [[ $URL_BASE =~ ^/file/.* ]]; then
 	send_file "${URL_BASE:1}"
 # run script
 # special case for root

--- a/docs/call-graph.md
+++ b/docs/call-graph.md
@@ -117,8 +117,9 @@ The same edges as a table, with the process boundaries spelled out:
 | `scripts/index.sh` | `init_environment`, `html_escape`, `send_response`                              |
 | `scripts/page.sh`  | `init_environment`, `send_error`, `send_file`                                   |
 
-`send_file` answers a 304 through `send_response`, but streams a 200 itself: `_send_header` then
-`cat`. `_send_header` writes the status line, the headers and the one access log line per request.
+`send_file` answers a 304 through `send_response`, but streams the body itself: `_send_header` then
+`cat` for a 200, or `tail -c | head -c` for a 206. `_send_header` writes the status line, the headers
+and the one access log line per request.
 
 Leaf functions (nothing below them but `log`/`log_debug`): `_check_encoding`, `_url_decode`,
 `html_escape`, `add_header`, `_get_mimetype`, `_send_header`.
@@ -135,7 +136,7 @@ failures through `_bail_request`, which owns the dump-and-log convention):
 | `parse_url`        | 400                               | invalid percent encoding                                  |
 | `_resolve_path`    | 404, 500                          | path missing or escaping the tree — never 403             |
 | `run_script`       | 404, 500                          | endpoint not executable, or it exited non-zero            |
-| `send_file`        | 404                               | not a readable regular file                               |
+| `send_file`        | 404, 416                          | not a readable regular file; unsatisfiable `Range`        |
 | `send_redirect`    | 500                               | no target, a CR or LF in it, or non-redirect code         |
 | `scripts/page.sh`  | 404, 405                          | missing `page` parameter; method not GET or HEAD          |
 
@@ -149,4 +150,6 @@ External commands
 | `stat`     | `send_file` (ETag, `Last-Modified`, `Content-Length`)        |
 | `date`     | `_send_header`                                               |
 | `cat`      | `send_file` (body), heredocs in `send_error` and `index.sh`  |
+| `tail`     | `send_file` (a range answer, piped into `head`)              |
+| `head`     | `send_file` (a range answer)                                 |
 | `envsubst` | `index.sh`                                                   |

--- a/docs/call-graph.md
+++ b/docs/call-graph.md
@@ -13,6 +13,7 @@ Processes
 sherver.sh ──exec──> socat ──fork+exec (per connection)──> dispatcher.sh
                                                                │ source scripts/SHERVER_UTILS.sh
                                                                │ init_environment
+                                                               ├─ method OPTIONS     ──> send_response 200
                                                                ├─ /file/*            ──> send_file
                                                                ├─ / or /index.htm[l] ──> run_script '/index.sh'
                                                                └─ anything else      ──> run_script "$REQUEST_URL"
@@ -59,6 +60,7 @@ flowchart TD
     dispatcher --> init_environment
     dispatcher --> send_file
     dispatcher --> run_script
+    dispatcher --> send_response
 
     init_environment --> read_request
     read_request --> bail_request
@@ -80,7 +82,6 @@ flowchart TD
     index --> init_environment
     index --> html_escape
     index --> send_response
-    index --> send_error
     page --> init_environment
     page --> send_error
     page --> send_file
@@ -102,7 +103,7 @@ The same edges as a table, with the process boundaries spelled out:
 | Caller             | Calls                                                                           |
 | ------------------ | ------------------------------------------------------------------------------- |
 | `sherver.sh`       | `socat` (exec: socat becomes the listener)                                      |
-| `dispatcher.sh`    | `init_environment`, then `send_file` or `run_script`                            |
+| `dispatcher.sh`    | `init_environment`, then `send_response` (OPTIONS), `send_file` or `run_script` |
 | `init_environment` | `read_request`                                                                  |
 | `read_request`     | `_bail_request`, `_check_encoding`, `parse_url`, `_url_decode`, `send_error`    |
 | `_bail_request`    | `send_error`                                                                    |
@@ -113,7 +114,7 @@ The same edges as a table, with the process boundaries spelled out:
 | `send_error`       | `send_response`                                                                 |
 | `send_redirect`    | `send_response`, `send_error`                                                   |
 | `send_response`    | `_send_header`                                                                  |
-| `scripts/index.sh` | `init_environment`, `html_escape`, `send_response`, `send_error`                |
+| `scripts/index.sh` | `init_environment`, `html_escape`, `send_response`                              |
 | `scripts/page.sh`  | `init_environment`, `send_error`, `send_file`                                   |
 
 `send_file` answers a 304 through `send_response`, but streams a 200 itself: `_send_header` then
@@ -128,16 +129,15 @@ Error codes
 Which function sends which code through `send_error` (`read_request` routes its early parse
 failures through `_bail_request`, which owns the dump-and-log convention):
 
-| Function           | Codes                        | Sent when                                                 |
-| ------------------ | ---------------------------- | --------------------------------------------------------- |
-| `read_request`     | 400, 405, 413, 414, 431, 505 | bad request line, header or body; method; version; limits |
-| `parse_url`        | 400                          | invalid percent encoding                                  |
-| `_resolve_path`    | 404, 500                     | path missing or escaping the tree — never 403             |
-| `run_script`       | 404, 500                     | endpoint not executable, or it exited non-zero            |
-| `send_file`        | 404                          | not a readable regular file                               |
-| `send_redirect`    | 500                          | no target, a CR or LF in it, or non-redirect code         |
-| `scripts/index.sh` | 405                          | method other than GET, HEAD or POST                       |
-| `scripts/page.sh`  | 404, 405                     | missing `page` parameter; method not GET or HEAD          |
+| Function           | Codes                             | Sent when                                                 |
+| ------------------ | --------------------------------- | --------------------------------------------------------- |
+| `read_request`     | 400, 405, 413, 414, 431, 501, 505 | bad request line, header or body; method; version; limits |
+| `parse_url`        | 400                               | invalid percent encoding                                  |
+| `_resolve_path`    | 404, 500                          | path missing or escaping the tree — never 403             |
+| `run_script`       | 404, 500                          | endpoint not executable, or it exited non-zero            |
+| `send_file`        | 404                               | not a readable regular file                               |
+| `send_redirect`    | 500                               | no target, a CR or LF in it, or non-redirect code         |
+| `scripts/page.sh`  | 404, 405                          | missing `page` parameter; method not GET or HEAD          |
 
 External commands
 -----------------

--- a/docs/call-graph.md
+++ b/docs/call-graph.md
@@ -41,6 +41,7 @@ flowchart TD
     subgraph library ["scripts/SHERVER_UTILS.sh"]
         init_environment
         read_request
+        bail_request["_bail_request (exit)"]
         parse_url
         check_encoding[_check_encoding]
         url_decode[_url_decode]
@@ -60,10 +61,12 @@ flowchart TD
     dispatcher --> run_script
 
     init_environment --> read_request
+    read_request --> bail_request
     read_request --> check_encoding
     read_request --> parse_url
     read_request --> url_decode
     read_request --> send_error
+    bail_request --> send_error
     parse_url --> check_encoding
     parse_url --> url_decode
     parse_url --> send_error
@@ -101,7 +104,8 @@ The same edges as a table, with the process boundaries spelled out:
 | `sherver.sh`       | `socat` (exec: socat becomes the listener)                                      |
 | `dispatcher.sh`    | `init_environment`, then `send_file` or `run_script`                            |
 | `init_environment` | `read_request`                                                                  |
-| `read_request`     | `_check_encoding`, `parse_url`, `_url_decode`, `send_error`                     |
+| `read_request`     | `_bail_request`, `_check_encoding`, `parse_url`, `_url_decode`, `send_error`    |
+| `_bail_request`    | `send_error`                                                                    |
 | `parse_url`        | `_check_encoding`, `_url_decode`, `send_error`                                  |
 | `run_script`       | `parse_url`, `_resolve_path`, `send_error`, the endpoint (exec)                 |
 | `send_file`        | `_resolve_path`, `_get_mimetype`, `send_response`, `_send_header`, `send_error` |
@@ -121,18 +125,19 @@ Leaf functions (nothing below them but `log`/`log_debug`): `_check_encoding`, `_
 Error codes
 -----------
 
-Which function sends which code through `send_error`:
+Which function sends which code through `send_error` (`read_request` routes its early parse
+failures through `_bail_request`, which owns the dump-and-log convention):
 
-| Function           | Codes                   | Sent when                                          |
-| ------------------ | ----------------------- | -------------------------------------------------- |
-| `read_request`     | 400, 405, 413, 414, 431 | bad request line, header or body; method; limits   |
-| `parse_url`        | 400                     | invalid percent encoding                           |
-| `_resolve_path`    | 404, 500                | path missing or escaping the tree — never 403      |
-| `run_script`       | 404, 500                | endpoint not executable, or it exited non-zero     |
-| `send_file`        | 404                     | not a readable regular file                        |
-| `send_redirect`    | 500                     | no target, a CR or LF in it, or non-redirect code  |
-| `scripts/index.sh` | 405                     | method other than GET, HEAD or POST                |
-| `scripts/page.sh`  | 404, 405                | missing `page` parameter; method not GET or HEAD   |
+| Function           | Codes                        | Sent when                                                 |
+| ------------------ | ---------------------------- | --------------------------------------------------------- |
+| `read_request`     | 400, 405, 413, 414, 431, 505 | bad request line, header or body; method; version; limits |
+| `parse_url`        | 400                          | invalid percent encoding                                  |
+| `_resolve_path`    | 404, 500                     | path missing or escaping the tree — never 403             |
+| `run_script`       | 404, 500                     | endpoint not executable, or it exited non-zero            |
+| `send_file`        | 404                          | not a readable regular file                               |
+| `send_redirect`    | 500                          | no target, a CR or LF in it, or non-redirect code         |
+| `scripts/index.sh` | 405                          | method other than GET, HEAD or POST                       |
+| `scripts/page.sh`  | 404, 405                     | missing `page` parameter; method not GET or HEAD          |
 
 External commands
 -----------------

--- a/docs/functions.md
+++ b/docs/functions.md
@@ -331,6 +331,8 @@ Every answer carries two cache validators: an `ETag` built from the size and mti
 
 Only a GET or a HEAD is answered that way: a 304 to a POST would leave the client without a representation of what it just sent.
 
+Every answer also announces `Accept-Ranges: bytes`, and a GET carrying a single byte range (`Range: bytes=0-499`, `bytes=500-`, `bytes=-500`) is answered with a `206 Partial Content` and the matching `Content-Range` — what `<video>` seeking needs. A range starting past the end of the file is a `416 Range Not Satisfiable`. Every other form — several ranges, another unit, garbage — is ignored and the whole file is served, as RFC 9110 §14.2 allows; so is the whole header when an `If-Range` is present and is not exactly the current ETag.
+
 The path generally comes from the URL (`URL_BASE`). You just need to remove the first `/` to get a relative path.
 
 *Note* that to find the correct mimetype, we use `_get_mimetype()`, which deduces it from the extension of the file.

--- a/docs/functions.md
+++ b/docs/functions.md
@@ -39,11 +39,11 @@ Use it for what is worth keeping on a busy server: errors, and the one line per 
 
 Examples
 
-     log "> HTTP/1.0 200 OK
+     log "> HTTP/1.1 200 OK
 
 will output
 
-     > HTTP/1.0 200 OK
+     > HTTP/1.1 200 OK
 
 
 `log_debug()`
@@ -154,7 +154,7 @@ Public: Add header for the response.
 
 Takes 2 parameters: header name and header content.
 
-* $1 - header name, one of the HTTP 1.0 standard value
+* $1 - header name, one of the HTTP 1.1 standard value
 * $2 - value of the header
 
 Examples
@@ -183,7 +183,7 @@ Examples
 
 will result in:
 
-     HTTP/1.0 200 OK
+     HTTP/1.1 200 OK
      Date: Thu, 04 Jul 2019 21:38:23 GMT
      Server: Sherver
      Cache-Control: private, max-age=60
@@ -193,7 +193,7 @@ will result in:
 `send_response()`
 -----------------
 
-Public: Send the given answer in a HTTP 1.0 format.
+Public: Send the given answer in a HTTP 1.1 format.
 
 Takes the response code as first parameter, then as many parameters as needed to write the answer. They will be sent, separated by newlines.
 
@@ -217,7 +217,7 @@ will send something like (depends on your default headers, see `RESPONSE_HEADERS
 
 ```
 
-     HTTP/1.0 200 OK
+     HTTP/1.1 200 OK
      Content-Type: text/plain
 
      this is some
@@ -240,7 +240,7 @@ Examples
 
 will create an answer that starts with
 
-     HTTP/1.0 404 Not Found
+     HTTP/1.1 404 Not Found
 
 
 `send_redirect()`
@@ -248,7 +248,7 @@ will create an answer that starts with
 
 Public: Send a redirect to the given URL as an answer.
 
-Takes the target URL, and optionally the response code: 302 (the default) for a temporary redirect, 301 for a permanent one — the two redirects HTTP 1.0 defines. Anything else is refused with a 500: `send_response` would die expanding an unknown code mid-answer, and the client would get nothing at all.
+Takes the target URL, and optionally the response code: 302 (the default) for a temporary redirect, 301 for a permanent one — the two redirects `HTTP_RESPONSE` knows. Anything else is refused with a 500: `send_response` would die expanding an unknown code mid-answer, and the client would get nothing at all.
 
 The typical use is POST-redirect-GET, so that a refresh doesn't resubmit the form.
 
@@ -265,7 +265,7 @@ Examples
 
 will send an answer that starts with
 
-     HTTP/1.0 302 Found
+     HTTP/1.1 302 Found
      Location: /index.sh
 
 
@@ -344,7 +344,7 @@ Examples
 
 if the file exist, will send a response that starts with (assuming file size is 4 kio)
 
-     HTTP/1.0 200 OK
+     HTTP/1.1 200 OK
      Content-Type: image/png
      Content-Length: 4096
 

--- a/docs/functions.md
+++ b/docs/functions.md
@@ -412,6 +412,8 @@ Reads the input stream and fills the following variables (also run `parse_url()`
 * `URL_BASE`
 * `URL_PARAMETERS`
 
+An absolute-form request target (`GET http://host/path`, RFC 9112 §3.2.2) is rewritten to the path it points at, and its authority — validated first — replaces `REQUEST_HEADERS['host']`. Any other target that is not a path is refused with a 400, the asterisk form of `OPTIONS` excepted.
+
 *Note* that this method is highly inspired by [bashttpd](https://github.com/avleen/bashttpd)
 
 * $1 - true when parsing from the standard input, false when re-parsing `REQUEST_FULL_STRING` in a child script. Only the first parse logs the request, so that a request is not dumped once per script it goes through

--- a/docs/functions.md
+++ b/docs/functions.md
@@ -187,7 +187,6 @@ will result in:
      Date: Thu, 04 Jul 2019 21:38:23 GMT
      Server: Sherver
      Cache-Control: private, max-age=60
-     Expires: Thu, 04 Jul 2019 21:38:23 GMT
 
 
 `send_response()`
@@ -232,6 +231,8 @@ Public: Send the given error as an answer.
 
 Takes one parameter: the error code. It will be sent as an answer, along with a very small HTML explaining what is the error.
 
+The answer is `Cache-Control: no-store` and carries none of the cache validators that may already have been set: this page is not the representation they describe, and several of these codes are triggered by a request header that nothing nominates in a `Vary`.
+
 * $1 - the error code, see `HTTP_RESPONSE`
 
 Examples
@@ -241,6 +242,7 @@ Examples
 will create an answer that starts with
 
      HTTP/1.1 404 Not Found
+     Cache-Control: no-store
 
 
 `send_redirect()`

--- a/docs/functions.md
+++ b/docs/functions.md
@@ -376,6 +376,24 @@ will do the following
      './index.sh' '/index.sh?dummy=stuff'
 
 
+`_bail_request()`
+-----------------
+
+Internal: Log a request parse failure, dump the request when relevant, and answer an error.
+
+**Note:** this method is used by `read_request()` and shouldn't be called manually.
+
+Owns the bail-out invariant of `read_request()`: the request is dumped on the first parse only (a child script re-parse would dump it once per script), the reason is always `log`ged, and `send_error()` ends the process — this function never returns. Only for the bail-outs *before* the end of the header loop: after that point, the first parse has already dumped the full request unconditionally, and this would dump it a second time.
+
+* $1 - the HTTP error code, one of the keys of `HTTP_RESPONSE`
+* $2 - the reason, `log`ged as is
+* $3 - true when parsing from the standard input, false in a child script re-parse
+
+Examples
+
+     _bail_request 400 'BAD REQUEST: malformed request line' true
+
+
 `read_request()`
 ----------------
 

--- a/docs/global-variables.md
+++ b/docs/global-variables.md
@@ -26,7 +26,9 @@ Public: The method of the request (one of GET, HEAD, POST and OPTIONS)
 `REQUEST_URL`
 -------------
 
-Public: The requested URL
+Public: The requested URL, always as a path (`*` alone for an asterisk-form `OPTIONS`)
+
+An absolute-form target (`GET http://host/path`, the form a proxy sends) is rewritten by `read_request()` to the path it points at, and any other non-path target is a 400, so scripts never see a scheme or a host.
 
 `REQUEST_HTTP_VERSION`
 ----------------------

--- a/docs/global-variables.md
+++ b/docs/global-variables.md
@@ -21,7 +21,7 @@ The dispatcher runs from the root, so we take the current directory. It is then 
 `REQUEST_METHOD`
 ----------------
 
-Public: The method of the request (GET, HEAD, POST...)
+Public: The method of the request (one of GET, HEAD, POST and OPTIONS)
 
 `REQUEST_URL`
 -------------
@@ -73,6 +73,13 @@ Public: The response headers (associative array)
 ---------------
 
 Public: Generic HTTP response code with their meaning (associative array)
+
+`SUPPORTED_METHODS`
+-------------------
+
+Public: The methods the server accepts, as an `Allow` header value
+
+`read_request()` tests the request method against it and sends it with its 405, and the dispatcher answers `OPTIONS` with it, so adding a method here cannot leave a stale `Allow` behind. A single script advertises its own list instead, `Allow` being a property of the target resource and not of the server (RFC 9110 §10.2.1).
 
 `MAX_BODY_SIZE`
 ---------------

--- a/docs/global-variables.md
+++ b/docs/global-variables.md
@@ -33,7 +33,7 @@ Public: The requested URL
 
 Public: The HTTP version the client announced (`HTTP/1.0`, `HTTP/1.1`...)
 
-Informative only: the answer is always in HTTP 1.1 (RFC 9112 §2.3 — the version in the response advertises capability, so answering 1.1 to a 1.0 client is correct).
+`read_request()` rejects anything that is not `HTTP/1.x` (400 when unparseable, 505 on another major version), so scripts only ever see 1.x here. The answer is always in HTTP 1.1 (RFC 9112 §2.3 — the version in the response advertises capability, so answering 1.1 to a 1.0 client is correct).
 
 `REQUEST_HEADERS`
 -----------------

--- a/docs/global-variables.md
+++ b/docs/global-variables.md
@@ -33,7 +33,7 @@ Public: The requested URL
 
 Public: The HTTP version the client announced (`HTTP/1.0`, `HTTP/1.1`...)
 
-Informative only: the answer is always in HTTP 1.0.
+Informative only: the answer is always in HTTP 1.1 (RFC 9112 §2.3 — the version in the response advertises capability, so answering 1.1 to a 1.0 client is correct).
 
 `REQUEST_HEADERS`
 -----------------

--- a/scripts/SHERVER_UTILS.sh
+++ b/scripts/SHERVER_UTILS.sh
@@ -876,6 +876,33 @@ function run_script()
 }
 export -f run_script
 
+# Internal: Log a request parse failure, dump the request when relevant, and answer an error.
+#
+# **Note:** this method is used by `read_request()` and shouldn't be called manually.
+#
+# Owns the bail-out invariant of `read_request()`: the request is dumped on the first parse
+# only (a child script re-parse would dump it once per script), the reason is always
+# `log`ged, and `send_error()` ends the process — this function never returns. Only for the
+# bail-outs *before* the end of the header loop: after that point, the first parse has
+# already dumped the full request unconditionally, and this would dump it a second time.
+#
+# $1 - the HTTP error code, one of the keys of `HTTP_RESPONSE`
+# $2 - the reason, `log`ged as is
+# $3 - true when parsing from the standard input, false in a child script re-parse
+#
+# Examples
+#
+#    _bail_request 400 'BAD REQUEST: malformed request line' true
+function _bail_request()
+{
+	if [ "$3" = true ]; then
+		log_debug "$REQUEST_FULL_STRING"
+	fi
+	log "$2"
+	send_error "$1"
+}
+export -f _bail_request
+
 # Internal: Read the client request and set up environment.
 #
 # **Note:** this method is used by the dispatcher and shouldn't be called manually.
@@ -914,45 +941,28 @@ function read_request()
 
 	# read URL
 	read -r REQUEST_METHOD REQUEST_URL REQUEST_HTTP_VERSION <<< "$line"
-	if [ -z "$REQUEST_METHOD" ] || [ -z "$REQUEST_URL" ] || [ -z "$REQUEST_HTTP_VERSION" ]; then
-		if [ "$1" = true ]; then
-			log_debug "$REQUEST_FULL_STRING"
-		fi
-		log 'BAD REQUEST: malformed request line'
-		send_error 400
+	# `read` collapses SP/TAB runs and drops trailing blanks (a leniency RFC 9112 §3 grants),
+	# so only non-whitespace extra tokens get glued into the version and rejected here.
+	# [0123456789] and not [0-9]: bracket ranges follow the locale and would take unicode digits
+	if [ -z "$REQUEST_METHOD" ] || [ -z "$REQUEST_URL" ] \
+			|| [[ ! "$REQUEST_HTTP_VERSION" =~ ^HTTP/[0123456789]\.[0123456789]$ ]]; then
+		_bail_request 400 'BAD REQUEST: malformed request line' "$1"
 	fi
-	# an unparseable version is a malformed request line — this also catches extra tokens,
-	# which the IFS split glues into the field; another major version is a 505 (RFC 9112 §2.3)
-	if [[ ! "$REQUEST_HTTP_VERSION" =~ ^HTTP/([0-9])\.[0-9]$ ]]; then
-		if [ "$1" = true ]; then
-			log_debug "$REQUEST_FULL_STRING"
-		fi
-		log "BAD REQUEST: unparseable HTTP version '$REQUEST_HTTP_VERSION'"
-		send_error 400
-	elif [ "${BASH_REMATCH[1]}" != '1' ]; then
-		if [ "$1" = true ]; then
-			log_debug "$REQUEST_FULL_STRING"
-		fi
-		log "UNSUPPORTED VERSION: '$REQUEST_HTTP_VERSION'"
-		send_error 505
+	# a literal `HTTP/0.9` token means the client speaks the 1.x line format (real 0.9 has no
+	# version token and took the 400 above), so a headered 505 is safe here (RFC 9112 §2.3)
+	if [[ "$REQUEST_HTTP_VERSION" != HTTP/1.* ]]; then
+		_bail_request 505 "UNSUPPORTED VERSION: '$REQUEST_HTTP_VERSION'" "$1"
 	fi
 	# Only GET, HEAD and POST are supported at this time
 	case "$REQUEST_METHOD" in
 		GET|HEAD|POST) ;;
 		*)
-			if [ "$1" = true ]; then
-				log_debug "$REQUEST_FULL_STRING"
-			fi
-			send_error 405
+			_bail_request 405 "METHOD NOT ALLOWED: '$REQUEST_METHOD'" "$1"
 			;;
 	esac
 	# `parse_url` decodes the URL, so a broken encoding can't be answered
 	if ! _check_encoding "$REQUEST_URL"; then
-		if [ "$1" = true ]; then
-			log_debug "$REQUEST_FULL_STRING"
-		fi
-		log "BAD REQUEST: invalid percent encoding in '$REQUEST_URL'"
-		send_error 400
+		_bail_request 400 "BAD REQUEST: invalid percent encoding in '$REQUEST_URL'" "$1"
 	fi
 	# fill URL_*
 	parse_url "$REQUEST_URL"
@@ -962,8 +972,7 @@ function read_request()
 	while read -r line; do
 		# checked first, for the same reasons as the request line above
 		if [ $(( ${#REQUEST_FULL_STRING} + ${#line} + 1 )) -gt "$MAX_HEADERS_SIZE" ]; then
-			log "TOO LARGE: headers over the $MAX_HEADERS_SIZE characters limit"
-			send_error 431
+			_bail_request 431 "TOO LARGE: headers over the $MAX_HEADERS_SIZE characters limit" "$1"
 		fi
 		line=${line%%$'\r'}
 		# reached the end of the headers, break.
@@ -975,8 +984,7 @@ $line"
 		IFS=$': \t' read -r key value <<< "$line"
 		# an empty name is a fatal `bad array subscript`, and only a broken client sends one
 		if [ -z "$key" ]; then
-			log 'BAD REQUEST: header line without a name'
-			send_error 400
+			_bail_request 400 'BAD REQUEST: header line without a name' "$1"
 		fi
 		# header names are case insensitive, so we normalize them to lowercase
 		REQUEST_HEADERS["${key,,}"]="$value"
@@ -984,10 +992,10 @@ $line"
 	if [ "$1" = true ]; then
 		log_debug "$REQUEST_FULL_STRING"
 	fi
-	# an HTTP 1.1 request must carry a Host header (RFC 9112 §3.2). Presence only:
-	# the value is not used (same tree served regardless) and duplicates still overwrite
-	if [ "$REQUEST_HTTP_VERSION" = 'HTTP/1.1' ] && [ ! -v "REQUEST_HEADERS['host']" ]; then
-		log 'BAD REQUEST: HTTP/1.1 request without a Host header'
+	# RFC 9112: §3.2 requires Host on 1.1, and §2.3 processes a higher 1.x minor as 1.1, so
+	# only 1.0 is exempt. Presence only: value unused (same tree served), duplicates overwrite
+	if [ "$REQUEST_HTTP_VERSION" != 'HTTP/1.0' ] && [ ! -v "REQUEST_HEADERS['host']" ]; then
+		log "BAD REQUEST: $REQUEST_HTTP_VERSION request without a Host header"
 		send_error 400
 	fi
 

--- a/scripts/SHERVER_UTILS.sh
+++ b/scripts/SHERVER_UTILS.sh
@@ -72,8 +72,10 @@ function init_environment()
 	declare -g REQUEST_URL=''
 	# Public: The HTTP version the client announced (`HTTP/1.0`, `HTTP/1.1`...)
 	#
-	# Informative only: the answer is always in HTTP 1.1 (RFC 9112 §2.3 — the version
-	# in the response advertises capability, so answering 1.1 to a 1.0 client is correct).
+	# `read_request()` rejects anything that is not `HTTP/1.x` (400 when unparseable, 505
+	# on another major version), so scripts only ever see 1.x here. The answer is always
+	# in HTTP 1.1 (RFC 9112 §2.3 — the version in the response advertises capability, so
+	# answering 1.1 to a 1.0 client is correct).
 	declare -g REQUEST_HTTP_VERSION=''
 	# Public: The headers from the request (associative array)
 	#
@@ -113,6 +115,7 @@ function init_environment()
 		[414]='URI Too Long'
 		[431]='Request Header Fields Too Large'
 		[500]='Internal Server Error'
+		[505]='HTTP Version Not Supported'
 	)
 	# Public: Biggest request body we accept to read, in bytes
 	#
@@ -917,6 +920,21 @@ function read_request()
 		fi
 		log 'BAD REQUEST: malformed request line'
 		send_error 400
+	fi
+	# an unparseable version is a malformed request line — this also catches extra tokens,
+	# which the IFS split glues into the field; another major version is a 505 (RFC 9112 §2.3)
+	if [[ ! "$REQUEST_HTTP_VERSION" =~ ^HTTP/([0-9])\.[0-9]$ ]]; then
+		if [ "$1" = true ]; then
+			log_debug "$REQUEST_FULL_STRING"
+		fi
+		log "BAD REQUEST: unparseable HTTP version '$REQUEST_HTTP_VERSION'"
+		send_error 400
+	elif [ "${BASH_REMATCH[1]}" != '1' ]; then
+		if [ "$1" = true ]; then
+			log_debug "$REQUEST_FULL_STRING"
+		fi
+		log "UNSUPPORTED VERSION: '$REQUEST_HTTP_VERSION'"
+		send_error 505
 	fi
 	# Only GET, HEAD and POST are supported at this time
 	case "$REQUEST_METHOD" in

--- a/scripts/SHERVER_UTILS.sh
+++ b/scripts/SHERVER_UTILS.sh
@@ -66,7 +66,7 @@ function init_environment()
 		SHERVER_ROOT=$(realpath .) || { log "FATAL: cannot canonicalize '$PWD'"; exit 1; }
 	fi
 	export SHERVER_ROOT
-	# Public: The method of the request (GET, HEAD, POST...)
+	# Public: The method of the request (one of GET, HEAD, POST and OPTIONS)
 	declare -g REQUEST_METHOD=''
 	# Public: The requested URL
 	declare -g REQUEST_URL=''
@@ -115,8 +115,16 @@ function init_environment()
 		[414]='URI Too Long'
 		[431]='Request Header Fields Too Large'
 		[500]='Internal Server Error'
+		[501]='Not Implemented'
 		[505]='HTTP Version Not Supported'
 	)
+	# Public: The methods the server accepts, as an `Allow` header value
+	#
+	# `read_request()` tests the request method against it and sends it with its 405, and the
+	# dispatcher answers `OPTIONS` with it, so adding a method here cannot leave a stale
+	# `Allow` behind. A single script advertises its own list instead, `Allow` being a property
+	# of the target resource and not of the server (RFC 9110 §10.2.1).
+	declare -rg SUPPORTED_METHODS='GET, HEAD, POST, OPTIONS'
 	# Public: Biggest request body we accept to read, in bytes
 	#
 	# The body ends up in `REQUEST_FULL_STRING`, which we export. Linux refuses to run a
@@ -953,13 +961,22 @@ function read_request()
 	if [[ "$REQUEST_HTTP_VERSION" != HTTP/1.* ]]; then
 		_bail_request 505 "UNSUPPORTED VERSION: '$REQUEST_HTTP_VERSION'" "$1"
 	fi
-	# Only GET, HEAD and POST are supported at this time
-	case "$REQUEST_METHOD" in
-		GET|HEAD|POST) ;;
-		*)
-			_bail_request 405 "METHOD NOT ALLOWED: '$REQUEST_METHOD'" "$1"
-			;;
-	esac
+	# Membership test and not a `case` pattern: a variable expanded into a pattern has its
+	# `|` taken literally, which would silently match nothing. Method names are case
+	# sensitive (RFC 9110 §9.1), so a lowercase `get` is an unknown method, not a GET
+	if [[ ",${SUPPORTED_METHODS// /}," != *",$REQUEST_METHOD,"* ]]; then
+		case "$REQUEST_METHOD" in
+			# a method we know but don't serve: 405 MUST carry `Allow` (RFC 9110 §15.5.6)
+			PUT|DELETE|PATCH|TRACE|CONNECT)
+				add_header 'Allow' "$SUPPORTED_METHODS"
+				_bail_request 405 "METHOD NOT ALLOWED: '$REQUEST_METHOD'" "$1"
+				;;
+			# a method we don't know at all is a 501, not a 405 (RFC 9110 §9.1)
+			*)
+				_bail_request 501 "METHOD NOT IMPLEMENTED: '$REQUEST_METHOD'" "$1"
+				;;
+		esac
+	fi
 	# `parse_url` decodes the URL, so a broken encoding can't be answered
 	if ! _check_encoding "$REQUEST_URL"; then
 		_bail_request 400 "BAD REQUEST: invalid percent encoding in '$REQUEST_URL'" "$1"

--- a/scripts/SHERVER_UTILS.sh
+++ b/scripts/SHERVER_UTILS.sh
@@ -984,6 +984,12 @@ $line"
 	if [ "$1" = true ]; then
 		log_debug "$REQUEST_FULL_STRING"
 	fi
+	# an HTTP 1.1 request must carry a Host header (RFC 9112 §3.2). Presence only:
+	# the value is not used (same tree served regardless) and duplicates still overwrite
+	if [ "$REQUEST_HTTP_VERSION" = 'HTTP/1.1' ] && [ ! -v "REQUEST_HEADERS['host']" ]; then
+		log 'BAD REQUEST: HTTP/1.1 request without a Host header'
+		send_error 400
+	fi
 
 	# fill REQUEST_BODY if POST
 	if [ "$REQUEST_METHOD" = 'POST' ] && [ -v "REQUEST_HEADERS['content-length']" ]; then

--- a/scripts/SHERVER_UTILS.sh
+++ b/scripts/SHERVER_UTILS.sh
@@ -68,7 +68,11 @@ function init_environment()
 	export SHERVER_ROOT
 	# Public: The method of the request (one of GET, HEAD, POST and OPTIONS)
 	declare -g REQUEST_METHOD=''
-	# Public: The requested URL
+	# Public: The requested URL, always as a path (`*` alone for an asterisk-form `OPTIONS`)
+	#
+	# An absolute-form target (`GET http://host/path`, the form a proxy sends) is rewritten
+	# by `read_request()` to the path it points at, and any other non-path target is a 400,
+	# so scripts never see a scheme or a host.
 	declare -g REQUEST_URL=''
 	# Public: The HTTP version the client announced (`HTTP/1.0`, `HTTP/1.1`...)
 	#
@@ -139,6 +143,11 @@ function init_environment()
 	declare -rg MAX_HEADERS_SIZE=$((8 * 1024))
 	# Internal: canonical path computed by `_resolve_path()`
 	declare -g RESOLVED_PATH=''
+	# Internal: the request-target exactly as the client sent it
+	#
+	# The access log reads it instead of `REQUEST_URL`, which loses the absolute form to the
+	# rewrite in `read_request()` — the log must keep proxy-style requests greppable.
+	declare -g REQUEST_TARGET=''
 	# Public: `true` when verbose logging is on, see `log_debug()`
 	#
 	# Read from the environment because that is the only channel that survives the exec into
@@ -389,7 +398,7 @@ function _send_header()
 	# the access log: the only line a quiet server writes for a request it served. socat's
 	# EXEC sets the peer address; a `-` means no socat in front, like the filter-driven
 	# tests. A request too broken to have a method is answered before those variables are filled
-	log "${SOCAT_PEERADDR:--} ${REQUEST_METHOD:--} ${REQUEST_URL:--} $1"
+	log "${SOCAT_PEERADDR:--} ${REQUEST_METHOD:--} ${REQUEST_TARGET:--} $1"
 	# HTTP header
 	log_debug "> HTTP/1.1 $1 ${HTTP_RESPONSE[$1]}"
 	# `printf`, not `echo -e`: a header value holding a literal `\r\n` would be turned into a
@@ -926,6 +935,11 @@ export -f _bail_request
 # * `URL_BASE`
 # * `URL_PARAMETERS`
 #
+# An absolute-form request target (`GET http://host/path`, RFC 9112 §3.2.2) is rewritten to
+# the path it points at, and its authority — validated first — replaces
+# `REQUEST_HEADERS['host']`. Any other target that is not a path is refused with a 400,
+# the asterisk form of `OPTIONS` excepted.
+#
 # *Note* that this method is highly inspired by [bashttpd](https://github.com/avleen/bashttpd)
 #
 # $1 - true when parsing from the standard input, false when re-parsing
@@ -949,11 +963,11 @@ function read_request()
 
 	# read URL
 	read -r REQUEST_METHOD REQUEST_URL REQUEST_HTTP_VERSION <<< "$line"
+	REQUEST_TARGET="$REQUEST_URL"	# saved before the rewrite below, for the access log
 	# `read` collapses SP/TAB runs and drops trailing blanks (a leniency RFC 9112 §3 grants),
 	# so only non-whitespace extra tokens get glued into the version and rejected here.
-	# [0123456789] and not [0-9]: bracket ranges follow the locale and would take unicode digits
 	if [ -z "$REQUEST_METHOD" ] || [ -z "$REQUEST_URL" ] \
-			|| [[ ! "$REQUEST_HTTP_VERSION" =~ ^HTTP/[0123456789]\.[0123456789]$ ]]; then
+			|| [[ ! "$REQUEST_HTTP_VERSION" =~ ^HTTP/[[:digit:]]\.[[:digit:]]$ ]]; then
 		_bail_request 400 'BAD REQUEST: malformed request line' "$1"
 	fi
 	# a literal `HTTP/0.9` token means the client speaks the 1.x line format (real 0.9 has no
@@ -976,6 +990,34 @@ function read_request()
 				_bail_request 501 "METHOD NOT IMPLEMENTED: '$REQUEST_METHOD'" "$1"
 				;;
 		esac
+	fi
+	# empty until the target proves absolute-form, then holds its validated authority
+	local authority=''
+	# RFC 9112 §3.2.2: the absolute-form target a proxy sends MUST be accepted. Rewritten to
+	# the origin form here, before anything reads the URL, so that `parse_url`,
+	# `_resolve_path` and the child scripts only ever see a path. Only the scheme is case
+	# insensitive (RFC 3986 §3.1), so everything is cut out of the original
+	if [[ "${REQUEST_URL,,}" =~ ^https?:// ]]; then
+		# a fragment is no part of a request-target (RFC 9112 §3.2), so it is cut off
+		# here rather than glued back onto the path
+		local -r target="${REQUEST_URL%%#*}"
+		# the authority ends at the first `/` or `?` (RFC 3986 §3.2), and what follows it
+		# keeps its own delimiter — cutting on `/` alone would eat a `?query`
+		local rest="${target#*://}"
+		authority="${rest%%[/?]*}"
+		rest="${rest:${#authority}}"
+		# RFC 9110 §4.2: an empty host is invalid in an http(s) URI and userinfo is an
+		# error — and nothing downstream `_check_encoding`s what lands in `Host` here
+		if [ -z "$authority" ] || [[ "$authority" == *@* ]] \
+				|| ! _check_encoding "$authority"; then
+			_bail_request 400 "BAD REQUEST: invalid authority in '$REQUEST_URL'" "$1"
+		fi
+		REQUEST_URL="/${rest#/}"	# an absolute URI needs no path, and no path is the root
+	fi
+	# RFC 9112 §3.2: past the rewrite the target must be a path — the asterisk form, that
+	# only `OPTIONS` may use, is the one exception. Nothing else may reach the routing
+	if [[ "$REQUEST_URL" != /* ]] && [ "$REQUEST_METHOD $REQUEST_URL" != 'OPTIONS *' ]; then
+		_bail_request 400 "BAD REQUEST: unsupported request target '$REQUEST_URL'" "$1"
 	fi
 	# `parse_url` decodes the URL, so a broken encoding can't be answered
 	if ! _check_encoding "$REQUEST_URL"; then
@@ -1009,6 +1051,12 @@ $line"
 	if [ "$1" = true ]; then
 		log_debug "$REQUEST_FULL_STRING"
 	fi
+	# RFC 9112 §3.2.2: with an absolute-form target, its authority wins and the `Host` header
+	# MUST be ignored. Done here and not with the rewrite above, where the header loop would
+	# then let a `Host:` line overwrite it and invert the MUST
+	if [ -n "$authority" ]; then
+		REQUEST_HEADERS['host']="$authority"
+	fi
 	# RFC 9112: §3.2 requires Host on 1.1, and §2.3 processes a higher 1.x minor as 1.1, so
 	# only 1.0 is exempt. Presence only: value unused (same tree served), duplicates overwrite
 	if [ "$REQUEST_HTTP_VERSION" != 'HTTP/1.0' ] && [ ! -v "REQUEST_HEADERS['host']" ]; then
@@ -1021,7 +1069,7 @@ $line"
 		local -r length="${REQUEST_HEADERS['content-length']}"
 		# a bogus length makes `read` fail with a bash error, and a huge one makes it wait
 		# for bytes that will never come, so we check it before using it
-		if [[ ! $length =~ ^[0-9]+$ ]]; then
+		if [[ ! $length =~ ^[[:digit:]]+$ ]]; then
 			log "BAD REQUEST: invalid Content-Length '$length'"
 			send_error 400
 		fi

--- a/scripts/SHERVER_UTILS.sh
+++ b/scripts/SHERVER_UTILS.sh
@@ -72,7 +72,8 @@ function init_environment()
 	declare -g REQUEST_URL=''
 	# Public: The HTTP version the client announced (`HTTP/1.0`, `HTTP/1.1`...)
 	#
-	# Informative only: the answer is always in HTTP 1.0.
+	# Informative only: the answer is always in HTTP 1.1 (RFC 9112 §2.3 — the version
+	# in the response advertises capability, so answering 1.1 to a 1.0 client is correct).
 	declare -g REQUEST_HTTP_VERSION=''
 	# Public: The headers from the request (associative array)
 	#
@@ -153,11 +154,11 @@ export -f init_environment
 #
 # Examples
 #
-#    log "> HTTP/1.0 200 OK
+#    log "> HTTP/1.1 200 OK
 #
 # will output
 #
-#    > HTTP/1.0 200 OK
+#    > HTTP/1.1 200 OK
 function log()
 {
 	printf '%s\n' "$@" >&2
@@ -335,7 +336,7 @@ export -f html_escape
 #
 # Takes 2 parameters: header name and header content.
 #
-# $1 - header name, one of the HTTP 1.0 standard value
+# $1 - header name, one of the HTTP 1.1 standard value
 # $2 - value of the header
 #
 # Examples
@@ -367,7 +368,7 @@ export -f add_header
 #
 # will result in:
 #
-#    HTTP/1.0 200 OK
+#    HTTP/1.1 200 OK
 #    Date: Thu, 04 Jul 2019 21:38:23 GMT
 #    Server: Sherver
 #    Cache-Control: private, max-age=60
@@ -379,10 +380,10 @@ function _send_header()
 	# tests. A request too broken to have a method is answered before those variables are filled
 	log "${SOCAT_PEERADDR:--} ${REQUEST_METHOD:--} ${REQUEST_URL:--} $1"
 	# HTTP header
-	log_debug "> HTTP/1.0 $1 ${HTTP_RESPONSE[$1]}"
+	log_debug "> HTTP/1.1 $1 ${HTTP_RESPONSE[$1]}"
 	# `printf`, not `echo -e`: a header value holding a literal `\r\n` would be turned into a
 	# real CRLF and inject a header of its own
-	printf 'HTTP/1.0 %s %s\r\n' "$1" "${HTTP_RESPONSE[$1]}"
+	printf 'HTTP/1.1 %s %s\r\n' "$1" "${HTTP_RESPONSE[$1]}"
 	# Date
 	local datenow
 	datenow=$(date -uR)
@@ -399,7 +400,7 @@ function _send_header()
 }
 export -f _send_header
 
-# Public: Send the given answer in a HTTP 1.0 format.
+# Public: Send the given answer in a HTTP 1.1 format.
 #
 # Takes the response code as first parameter, then as many parameters as needed to write the answer.
 # They will be sent, separated by newlines.
@@ -425,7 +426,7 @@ export -f _send_header
 #
 # ```
 #
-#    HTTP/1.0 200 OK
+#    HTTP/1.1 200 OK
 #    Content-Type: text/plain
 #
 #    this is some
@@ -473,7 +474,7 @@ export -f send_response
 #
 # will create an answer that starts with
 #
-#    HTTP/1.0 404 Not Found
+#    HTTP/1.1 404 Not Found
 function send_error()
 {
 	# the access log already carries the code, so this one is only useful next to a dump
@@ -503,7 +504,7 @@ export -f send_error
 # Public: Send a redirect to the given URL as an answer.
 #
 # Takes the target URL, and optionally the response code: 302 (the default) for a
-# temporary redirect, 301 for a permanent one — the two redirects HTTP 1.0 defines.
+# temporary redirect, 301 for a permanent one — the two redirects `HTTP_RESPONSE` knows.
 # Anything else is refused with a 500: `send_response` would die expanding an unknown
 # code mid-answer, and the client would get nothing at all.
 #
@@ -525,7 +526,7 @@ export -f send_error
 #
 # will send an answer that starts with
 #
-#    HTTP/1.0 302 Found
+#    HTTP/1.1 302 Found
 #    Location: /index.sh
 function send_redirect()
 {
@@ -768,7 +769,7 @@ export -f _get_mimetype
 #
 # if the file exist, will send a response that starts with (assuming file size is 4 kio)
 #
-#    HTTP/1.0 200 OK
+#    HTTP/1.1 200 OK
 #    Content-Type: image/png
 #    Content-Length: 4096
 function send_file()

--- a/scripts/SHERVER_UTILS.sh
+++ b/scripts/SHERVER_UTILS.sh
@@ -108,6 +108,7 @@ function init_environment()
 	# Public: Generic HTTP response code with their meaning (associative array)
 	declare -rAg HTTP_RESPONSE=(
 		[200]='OK'
+		[206]='Partial Content'
 		[301]='Moved Permanently'
 		[302]='Found'
 		[304]='Not Modified'
@@ -117,6 +118,7 @@ function init_environment()
 		[405]='Method Not Allowed'
 		[413]='Content Too Large'
 		[414]='URI Too Long'
+		[416]='Range Not Satisfiable'
 		[431]='Request Header Fields Too Large'
 		[500]='Internal Server Error'
 		[501]='Not Implemented'
@@ -774,6 +776,14 @@ export -f _get_mimetype
 # Only a GET or a HEAD is answered that way: a 304 to a POST would leave the client
 # without a representation of what it just sent.
 #
+# Every answer also announces `Accept-Ranges: bytes`, and a GET carrying a single byte
+# range (`Range: bytes=0-499`, `bytes=500-`, `bytes=-500`) is answered with a
+# `206 Partial Content` and the matching `Content-Range` — what `<video>` seeking needs.
+# A range starting past the end of the file is a `416 Range Not Satisfiable`. Every
+# other form — several ranges, another unit, garbage — is ignored and the whole file is
+# served, as RFC 9110 §14.2 allows; so is the whole header when an `If-Range` is present
+# and is not exactly the current ETag.
+#
 # The path generally comes from the URL (`URL_BASE`). You just need to remove the first
 # `/` to get a relative path.
 #
@@ -841,11 +851,69 @@ function send_file()
 	local content_type
 	content_type=$(_get_mimetype "$file")
 	add_header 'Content-Type'   "$content_type";
-	add_header 'Content-Length' "$size"
-	_send_header 200
-	# response
-	if [ "$REQUEST_METHOD" != 'HEAD' ]; then
-		cat "$file"
+	# on the 200s as much as the 206s: this is what tells a video player seeking works
+	add_header 'Accept-Ranges' 'bytes'
+	# single byte range, on GET only (RFC 9110 §14.2 lets a HEAD ignore Range, and it keeps
+	# the full-size headers meaningful). `first` stays -1 unless a satisfiable range lands
+	local -i first=-1 last=-1
+	# anything unparseable — several ranges, another unit, garbage, a number too long for
+	# bash's 64-bit arithmetic — falls through to the full 200: §14.2 allows ignoring the
+	# header wholesale, so the full answer is always a correct one, never an error
+	if [ "$REQUEST_METHOD" = 'GET' ] \
+			&& [[ "${REQUEST_HEADERS['range']:-}" =~ ^bytes=([[:digit:]]*)-([[:digit:]]*)$ ]] \
+			&& [ -n "${BASH_REMATCH[1]}${BASH_REMATCH[2]}" ] \
+			&& [ "${#BASH_REMATCH[1]}" -le 18 ] && [ "${#BASH_REMATCH[2]}" -le 18 ]; then
+		# `10#` pins base ten: a client's leading zero would otherwise read as octal, and
+		# `bytes=08-` would die on an invalid constant. The 18-digits cap above keeps the
+		# conversion inside bash's arithmetic range
+		local -r from="${BASH_REMATCH[1]:+$(( 10#${BASH_REMATCH[1]} ))}"
+		local -r to="${BASH_REMATCH[2]:+$(( 10#${BASH_REMATCH[2]} ))}"
+		# a stale If-Range means the client's copy changed under it: it needs the whole
+		# file, not a piece of the new one. Exact string match, like the validators above
+		local -r if_range="${REQUEST_HEADERS['if-range']:-}"
+		if [ -z "$if_range" ] || [ "$if_range" = "$etag" ]; then
+			if [ -z "$from" ]; then
+				# `-N` is the last N bytes, the whole file when N overshoots it
+				if [ "$to" -gt 0 ] && [ "$size" -gt 0 ]; then
+					first=$(( size > to ? size - to : 0 ))
+					last=$(( size - 1 ))
+				else
+					# the last zero bytes, or any tail of an empty file, selects nothing
+					# (RFC 9110 §14.1.2); §15.3.7 wants the full size in the answer
+					add_header 'Content-Range' "bytes */$size"
+					send_error 416
+				fi
+			elif [ -n "$to" ] && [ "$from" -gt "$to" ]; then
+				: # first past last is no range at all: ignored, the 200 below answers
+			elif [ "$from" -ge "$size" ]; then
+				# the one unsatisfiable int-range form: it starts past the end
+				add_header 'Content-Range' "bytes */$size"
+				send_error 416
+			else
+				first="$from"
+				# an open or overshooting end stops where the file does (RFC 9110 §14.1.2)
+				if [ -z "$to" ] || [ "$to" -ge "$size" ]; then
+					last=$(( size - 1 ))
+				else
+					last="$to"
+				fi
+			fi
+		fi
+	fi
+	if [ "$first" -ge 0 ]; then
+		local -ri length=$(( last - first + 1 ))
+		add_header 'Content-Range' "bytes $first-$last/$size"
+		add_header 'Content-Length' "$length"
+		_send_header 206
+		# no `pipefail` here, so `tail` dying of SIGPIPE once `head` has enough is inert
+		tail -c "+$(( first + 1 ))" -- "$file" | head -c "$length"
+	else
+		add_header 'Content-Length' "$size"
+		_send_header 200
+		# response
+		if [ "$REQUEST_METHOD" != 'HEAD' ]; then
+			cat "$file"
+		fi
 	fi
 	log_debug '================================================'
 	exit 0

--- a/scripts/SHERVER_UTILS.sh
+++ b/scripts/SHERVER_UTILS.sh
@@ -394,7 +394,6 @@ export -f add_header
 #    Date: Thu, 04 Jul 2019 21:38:23 GMT
 #    Server: Sherver
 #    Cache-Control: private, max-age=60
-#    Expires: Thu, 04 Jul 2019 21:38:23 GMT
 function _send_header()
 {
 	# the access log: the only line a quiet server writes for a request it served. socat's
@@ -406,12 +405,13 @@ function _send_header()
 	# `printf`, not `echo -e`: a header value holding a literal `\r\n` would be turned into a
 	# real CRLF and inject a header of its own
 	printf 'HTTP/1.1 %s %s\r\n' "$1" "${HTTP_RESPONSE[$1]}"
-	# Date
+	# Date. No `Expires` next to it: `Cache-Control` already carries the lifetime, and a cache
+	# must ignore `Expires` whenever `max-age` is there (RFC 9111 §5.3), so the second field
+	# only ever gets to disagree with the first
 	local datenow
 	datenow=$(date -uR)
 	datenow=${datenow/%+0000/GMT}
 	add_header 'Date' "$datenow"
-	add_header 'Expires' "$datenow"
 	# rest of the headers
 	local i
 	for i in "${!RESPONSE_HEADERS[@]}"; do
@@ -488,6 +488,10 @@ export -f send_response
 # Takes one parameter: the error code. It will be sent as an answer, along with a very small
 # HTML explaining what is the error.
 #
+# The answer is `Cache-Control: no-store` and carries none of the cache validators that may
+# already have been set: this page is not the representation they describe, and several of
+# these codes are triggered by a request header that nothing nominates in a `Vary`.
+#
 # $1 - the error code, see `HTTP_RESPONSE`
 #
 # Examples
@@ -497,6 +501,7 @@ export -f send_response
 # will create an answer that starts with
 #
 #    HTTP/1.1 404 Not Found
+#    Cache-Control: no-store
 function send_error()
 {
 	# the access log already carries the code, so this one is only useful next to a dump
@@ -519,6 +524,12 @@ function send_error()
 EOF
 )
 	add_header 'Content-Type' 'text/html; charset=utf-8'
+	# a 416 gets here holding the ETag and the date of the file it refused a range of, and
+	# they describe that file, not this page
+	unset -v 'RESPONSE_HEADERS[ETag]' 'RESPONSE_HEADERS[Last-Modified]'
+	# nothing puts `Range` — or a header length, or the version — in a `Vary`, so a stored
+	# 416, 431 or 505 could be replayed for a later request the server would have answered
+	add_header 'Cache-Control' 'no-store'
 	send_response "$@" "$html"
 }
 export -f send_error
@@ -859,15 +870,16 @@ function send_file()
 	# anything unparseable — several ranges, another unit, garbage, a number too long for
 	# bash's 64-bit arithmetic — falls through to the full 200: §14.2 allows ignoring the
 	# header wholesale, so the full answer is always a correct one, never an error
+	# each number is captured twice: the outer group makes it optional, the inner one holds it
+	# without its leading zeros, so the 18-digit cap measures its magnitude and not its padding
 	if [ "$REQUEST_METHOD" = 'GET' ] \
-			&& [[ "${REQUEST_HEADERS['range']:-}" =~ ^bytes=([[:digit:]]*)-([[:digit:]]*)$ ]] \
-			&& [ -n "${BASH_REMATCH[1]}${BASH_REMATCH[2]}" ] \
-			&& [ "${#BASH_REMATCH[1]}" -le 18 ] && [ "${#BASH_REMATCH[2]}" -le 18 ]; then
-		# `10#` pins base ten: a client's leading zero would otherwise read as octal, and
-		# `bytes=08-` would die on an invalid constant. The 18-digits cap above keeps the
-		# conversion inside bash's arithmetic range
-		local -r from="${BASH_REMATCH[1]:+$(( 10#${BASH_REMATCH[1]} ))}"
-		local -r to="${BASH_REMATCH[2]:+$(( 10#${BASH_REMATCH[2]} ))}"
+			&& [[ "${REQUEST_HEADERS['range']:-}" =~ ^bytes=(0*([[:digit:]]+))?-(0*([[:digit:]]+))?$ ]] \
+			&& [ -n "${BASH_REMATCH[2]}${BASH_REMATCH[4]}" ] \
+			&& [ "${#BASH_REMATCH[2]}" -le 18 ] && [ "${#BASH_REMATCH[4]}" -le 18 ]; then
+		# the regex already dropped the zeros, so `10#` is only a belt-and-braces base-ten
+		# pin: without it a padded value would read as octal, and `bytes=08-` would die
+		local -r from="${BASH_REMATCH[2]:+$(( 10#${BASH_REMATCH[2]} ))}"
+		local -r to="${BASH_REMATCH[4]:+$(( 10#${BASH_REMATCH[4]} ))}"
 		# a stale If-Range means the client's copy changed under it: it needs the whole
 		# file, not a piece of the new one. Exact string match, like the validators above
 		local -r if_range="${REQUEST_HEADERS['if-range']:-}"
@@ -1016,6 +1028,8 @@ export -f _bail_request
 function read_request()
 {
 	local line
+	# this bail-out and the 414 below stay outside `_bail_request`: `REQUEST_FULL_STRING`
+	# is not filled yet, so its debug dump would be empty
 	if ! read -r line; then
 		log 'BAD REQUEST: empty request'
 		send_error 400
@@ -1043,9 +1057,16 @@ function read_request()
 	if [[ "$REQUEST_HTTP_VERSION" != HTTP/1.* ]]; then
 		_bail_request 505 "UNSUPPORTED VERSION: '$REQUEST_HTTP_VERSION'" "$1"
 	fi
+	# RFC 9112 §3: a method is a token (RFC 9110 §5.6.2 tchar), so a stray octet in it is a
+	# malformed request line — a 400 — where a well-formed unknown method is a 501 below
+	local -r tchar=$'^[[:alnum:]!#$%&\'*+.^_`|~-]+$'
+	if [[ ! "$REQUEST_METHOD" =~ $tchar ]]; then
+		_bail_request 400 "BAD REQUEST: invalid method token '$REQUEST_METHOD'" "$1"
+	fi
 	# Membership test and not a `case` pattern: a variable expanded into a pattern has its
-	# `|` taken literally, which would silently match nothing. Method names are case
-	# sensitive (RFC 9110 §9.1), so a lowercase `get` is an unknown method, not a GET
+	# `|` taken literally, which would silently match nothing. Exact because the tchar check
+	# above keeps the `,` delimiter out of the method, so it cannot span two list entries.
+	# Method names are case sensitive (RFC 9110 §9.1): a lowercase `get` is not a GET
 	if [[ ",${SUPPORTED_METHODS// /}," != *",$REQUEST_METHOD,"* ]]; then
 		case "$REQUEST_METHOD" in
 			# a method we know but don't serve: 405 MUST carry `Allow` (RFC 9110 §15.5.6)
@@ -1074,9 +1095,10 @@ function read_request()
 		local rest="${target#*://}"
 		authority="${rest%%[/?]*}"
 		rest="${rest:${#authority}}"
-		# RFC 9110 §4.2: an empty host is invalid in an http(s) URI and userinfo is an
-		# error — and nothing downstream `_check_encoding`s what lands in `Host` here
-		if [ -z "$authority" ] || [[ "$authority" == *@* ]] \
+		# RFC 9110 §4.2: an empty host — bare or in front of a `:port` — is invalid in an
+		# http(s) URI and userinfo is an error — and nothing downstream `_check_encoding`s
+		# what lands in `Host` here
+		if [ -z "${authority%%:*}" ] || [[ "$authority" == *@* ]] \
 				|| ! _check_encoding "$authority"; then
 			_bail_request 400 "BAD REQUEST: invalid authority in '$REQUEST_URL'" "$1"
 		fi
@@ -1134,13 +1156,16 @@ $line"
 
 	# fill REQUEST_BODY if POST
 	if [ "$REQUEST_METHOD" = 'POST' ] && [ -v "REQUEST_HEADERS['content-length']" ]; then
-		local -r length="${REQUEST_HEADERS['content-length']}"
+		local -r raw_length="${REQUEST_HEADERS['content-length']}"
 		# a bogus length makes `read` fail with a bash error, and a huge one makes it wait
 		# for bytes that will never come, so we check it before using it
-		if [[ ! $length =~ ^[[:digit:]]+$ ]]; then
-			log "BAD REQUEST: invalid Content-Length '$length'"
+		if [[ ! $raw_length =~ ^0*([[:digit:]]+)$ ]]; then
+			log "BAD REQUEST: invalid Content-Length '$raw_length'"
 			send_error 400
 		fi
+		# the group drops the leading zeros `1*DIGIT` allows, so the cap below measures the
+		# magnitude and not the padding — same rule as the Range parser
+		local -r length="${BASH_REMATCH[1]}"
 		# outside `test`'s integer range, `-gt` errors out and counts as false, which would
 		# silently skip the limit. 10 digits is far above the limit anyway
 		if [ "${#length}" -gt 10 ] || [ "$length" -gt "$MAX_BODY_SIZE" ]; then

--- a/scripts/index.sh
+++ b/scripts/index.sh
@@ -19,12 +19,12 @@ set -efu
 
 init_environment
 
+# no 405 arm: this endpoint serves every method `SUPPORTED_METHODS` lets through, OPTIONS
+# being answered by the dispatcher. An endpoint that doesn't, like `page.sh`, needs one
 if [ "$REQUEST_METHOD" = 'POST' ]; then
 	add_header 'Content-Type' 'text/plain'
 	send_response 200 "You just sent me '$REQUEST_BODY'!
 	How kind of you <3"
-elif [ "$REQUEST_METHOD" != 'GET' ] && [ "$REQUEST_METHOD" != 'HEAD' ]; then
-	send_error 405
 fi
 
 all_params=''

--- a/scripts/page.sh
+++ b/scripts/page.sh
@@ -19,7 +19,10 @@ set -efu
 
 init_environment
 
+# OPTIONS is advertised but not accepted here: the dispatcher answers it before routing,
+# so it never reaches a script. Handle it in the test below if that ever changes
 if [ "$REQUEST_METHOD" != 'GET' ] && [ "$REQUEST_METHOD" != 'HEAD' ]; then
+	add_header 'Allow' 'GET, HEAD, OPTIONS'
 	send_error 405
 fi
 # `:-` because `set -u` makes a missing key fatal, which would end up as a 500

--- a/sherver.sh
+++ b/sherver.sh
@@ -19,7 +19,7 @@ set -efu
 
 cd "$(dirname "$0")"
 
-declare -r SHERVER_VERSION='1.0'
+declare -r SHERVER_VERSION='1.1'
 
 # the environment is the only thing the dispatcher and the scripts it runs inherit from us
 if [ "${1:-}" = '--debug' ]; then

--- a/sherver.sh
+++ b/sherver.sh
@@ -61,8 +61,12 @@ esac
 
 printf 'Sherver %s started, listening on %s\n' "$SHERVER_VERSION" "${1:-8080}" >&2
 
-# -T: drop a connection that goes silent, so a client can't pin a forked child forever
-# exec: socat replaces us, so systemd tracks and signals it instead of a bash wrapper
+
 # IFS joins the array into socat's one comma-separated argument, and dies with the exec
 IFS=','
-exec socat -T 10 "${socat_options[*]}" EXEC:'./dispatcher.sh'
+# exec: socat replaces us, so systemd tracks and signals it instead of a bash wrapper
+exec socat \
+	`# -T: drop a connection that goes silent, so a client can't pin a forked child forever` \
+	-T 10 \
+	"${socat_options[*]}" \
+	EXEC:'./dispatcher.sh'

--- a/tests/confinement.bats
+++ b/tests/confinement.bats
@@ -68,6 +68,14 @@ function teardown()
 	refuses '/file//etc/passwd'
 }
 
+@test "an escape hidden in an absolute-form target is refused" {
+	# the target is rewritten to its path before anything resolves it, so it lands in the
+	# same check as an origin form — the authority is no way around it
+	refuses 'http://example.com/file/../dispatcher.sh'
+	refuses 'https://example.com/../../etc/passwd'
+	refuses 'http://example.com//etc/passwd'
+}
+
 @test "a percent encoded escape is refused" {
 	# the URL is decoded before it is resolved, so this is the same as `..`
 	refuses '/file/%2e%2e/dispatcher.sh'

--- a/tests/confinement.bats
+++ b/tests/confinement.bats
@@ -24,17 +24,17 @@ load 'test_helper'
 # Internal: Check that the given URL is refused, and that the refusal leaks nothing.
 function refuses()
 {
-	request '' "GET $1 HTTP/1.0"
+	request '' "GET $1 HTTP/1.1" 'Host: localhost'
 	[ "$(status_code)" = '404' ]
 	# a 403 would confirm the target exists, and the body must not name it either
-	[ "$(status_line)" = 'HTTP/1.0 404 Not Found' ]
+	[ "$(status_line)" = 'HTTP/1.1 404 Not Found' ]
 	[[ "$(body)" != *"$REPO_ROOT"* ]]
 }
 
 # Internal: Check that the given URL is served with a 200.
 function serves()
 {
-	request '' "GET $1 HTTP/1.0"
+	request '' "GET $1 HTTP/1.1" 'Host: localhost'
 	[ "$(status_code)" = '200' ]
 }
 
@@ -114,7 +114,7 @@ function teardown()
 	local url
 	for url in '/file/../dispatcher.sh' '/../etc/passwd' '/file/nope' '/nope.sh' \
 		'/templates/template.html' '/page.sh?page=../../LICENSE'; do
-		request '' "GET $url HTTP/1.0"
+		request '' "GET $url HTTP/1.1" 'Host: localhost'
 		[ "$(status_code)" != '403' ]
 	done
 }

--- a/tests/files.bats
+++ b/tests/files.bats
@@ -207,6 +207,35 @@ load 'test_helper'
 	[ "$(header Content-Range)" = "bytes */$size" ]
 }
 
+@test "a 416 is uncacheable and carries none of the file's validators" {
+	request '' 'GET /file/venise.webp HTTP/1.1' 'Host: localhost' 'Range: bytes=999999999-'
+	[ "$(status_code)" = '416' ]
+	# nothing nominates Range in a Vary, so a storable 416 could be replayed for a plain GET
+	[ "$(header Cache-Control)" = 'no-store' ]
+	# this is the one error path reached with the validators of a file already set: they
+	# describe that file, and the body here is the error page
+	local -r names="$(header_names)"
+	[[ "$names" != *etag* ]]
+	[[ "$names" != *last-modified* ]]
+}
+
+@test "leading zeros in a range are legal digits, not garbage" {
+	local -r size="$(stat -c '%s' "$REPO_ROOT/file/venise.webp")"
+	# RFC 9110 reads these as `1*DIGIT`: 21 digits of padding is still the number 3
+	request '' 'GET /file/venise.webp HTTP/1.1' 'Host: localhost' 'Range: bytes=000-000000000000000000003'
+	[ "$(status_code)" = '206' ]
+	[ "$(header Content-Range)" = "bytes 0-3/$size" ]
+	[ "$(header Content-Length)" = '4' ]
+
+	request '' 'GET /file/venise.webp HTTP/1.1' 'Host: localhost' 'Range: bytes=-0000000000000000000004'
+	[ "$(status_code)" = '206' ]
+	[ "$(header Content-Range)" = "bytes $(( size - 4 ))-$(( size - 1 ))/$size" ]
+
+	# and a padded zero-length suffix is still the 416 that `bytes=-0` is
+	request '' 'GET /file/venise.webp HTTP/1.1' 'Host: localhost' 'Range: bytes=-000'
+	[ "$(status_code)" = '416' ]
+}
+
 @test "an unparseable or multi-range Range is ignored, never an error" {
 	local -r size="$(stat -c '%s' "$REPO_ROOT/file/venise.webp")"
 	local range

--- a/tests/files.bats
+++ b/tests/files.bats
@@ -18,7 +18,7 @@
 load 'test_helper'
 
 @test "a file is served whole and unaltered" {
-	request '' 'GET /file/venise.webp HTTP/1.0'
+	request '' 'GET /file/venise.webp HTTP/1.1' 'Host: localhost'
 	[ "$(status_code)" = '200' ]
 	[ "$(header Content-Length)" = "$(stat -c '%s' "$REPO_ROOT/file/venise.webp")" ]
 	body > "$BATS_TEST_TMPDIR/served"
@@ -28,7 +28,7 @@ load 'test_helper'
 @test "the mime type comes from the extension, and text types announce utf-8" {
 	local file type
 	while read -r file type; do
-		request '' "GET /file/$file HTTP/1.0"
+		request '' "GET /file/$file HTTP/1.1" 'Host: localhost'
 		[ "$(status_code)" = '200' ]
 		[ "$(header Content-Type)" = "$type" ]
 	done <<-'EOF'
@@ -40,13 +40,13 @@ load 'test_helper'
 }
 
 @test "HEAD of a file repeats the headers of the GET exactly" {
-	request '' 'GET /file/venise.webp HTTP/1.0'
+	request '' 'GET /file/venise.webp HTTP/1.1' 'Host: localhost'
 	local -r get_type="$(header Content-Type)"
 	local -r get_length="$(header Content-Length)"
 	local -r get_etag="$(header ETag)"
 	local -r get_names="$(header_names)"
 
-	request '' 'HEAD /file/venise.webp HTTP/1.0'
+	request '' 'HEAD /file/venise.webp HTTP/1.1' 'Host: localhost'
 	[ "$(status_code)" = '200' ]
 	[ -z "$(body)" ]
 	[ "$(header Content-Type)" = "$get_type" ]
@@ -56,15 +56,15 @@ load 'test_helper'
 }
 
 @test "a file answers with an ETag built from its size and mtime" {
-	request '' 'GET /file/venise.webp HTTP/1.0'
+	request '' 'GET /file/venise.webp HTTP/1.1' 'Host: localhost'
 	[ "$(header ETag)" = "\"$(stat -c '%s-%Y' "$REPO_ROOT/file/venise.webp")\"" ]
 }
 
 @test "a matching If-None-Match is answered with a bodyless 304" {
-	request '' 'GET /file/venise.webp HTTP/1.0'
+	request '' 'GET /file/venise.webp HTTP/1.1' 'Host: localhost'
 	local -r etag="$(header ETag)"
 
-	request '' 'GET /file/venise.webp HTTP/1.0' "If-None-Match: $etag"
+	request '' 'GET /file/venise.webp HTTP/1.1' 'Host: localhost' "If-None-Match: $etag"
 	[ "$(status_code)" = '304' ]
 	[ -z "$(body)" ]
 	# a 304 carries the length of the answer it replaces, which the server cannot know
@@ -72,99 +72,99 @@ load 'test_helper'
 }
 
 @test "a stale If-None-Match gets the file again" {
-	request '' 'GET /file/venise.webp HTTP/1.0' 'If-None-Match: "0-0"'
+	request '' 'GET /file/venise.webp HTTP/1.1' 'Host: localhost' 'If-None-Match: "0-0"'
 	[ "$(status_code)" = '200' ]
 	[ -n "$(body)" ]
 }
 
 @test "a file answers with its Last-Modified date" {
-	request '' 'GET /file/venise.webp HTTP/1.0'
+	request '' 'GET /file/venise.webp HTTP/1.1' 'Host: localhost'
 	local expected
 	expected="$(date -uR -r "$REPO_ROOT/file/venise.webp")"
 	[ "$(header Last-Modified)" = "${expected/%+0000/GMT}" ]
 }
 
 @test "a matching If-Modified-Since is answered with a bodyless 304" {
-	request '' 'GET /file/venise.webp HTTP/1.0'
+	request '' 'GET /file/venise.webp HTTP/1.1' 'Host: localhost'
 	local -r date="$(header Last-Modified)"
 
-	request '' 'GET /file/venise.webp HTTP/1.0' "If-Modified-Since: $date"
+	request '' 'GET /file/venise.webp HTTP/1.1' 'Host: localhost' "If-Modified-Since: $date"
 	[ "$(status_code)" = '304' ]
 	[ -z "$(body)" ]
 }
 
 @test "an If-Modified-Since that is not ours gets the file again" {
 	# the comparison is an exact string match, like the ETag one
-	request '' 'GET /file/venise.webp HTTP/1.0' 'If-Modified-Since: Thu, 04 Jul 2019 21:38:23 GMT'
+	request '' 'GET /file/venise.webp HTTP/1.1' 'Host: localhost' 'If-Modified-Since: Thu, 04 Jul 2019 21:38:23 GMT'
 	[ "$(status_code)" = '200' ]
 	[ -n "$(body)" ]
 }
 
 @test "If-None-Match alone decides when both validators are sent" {
-	request '' 'GET /file/venise.webp HTTP/1.0'
+	request '' 'GET /file/venise.webp HTTP/1.1' 'Host: localhost'
 	local -r etag="$(header ETag)"
 	local -r date="$(header Last-Modified)"
 
 	# a stale ETag must win over a matching date...
-	request '' 'GET /file/venise.webp HTTP/1.0' 'If-None-Match: "0-0"' "If-Modified-Since: $date"
+	request '' 'GET /file/venise.webp HTTP/1.1' 'Host: localhost' 'If-None-Match: "0-0"' "If-Modified-Since: $date"
 	[ "$(status_code)" = '200' ]
 	# ...and a matching ETag over a stale date
-	request '' 'GET /file/venise.webp HTTP/1.0' "If-None-Match: $etag" \
+	request '' 'GET /file/venise.webp HTTP/1.1' 'Host: localhost' "If-None-Match: $etag" \
 		'If-Modified-Since: Thu, 04 Jul 2019 21:38:23 GMT'
 	[ "$(status_code)" = '304' ]
 }
 
 @test "an empty If-None-Match does not swallow the If-Modified-Since" {
-	request '' 'GET /file/venise.webp HTTP/1.0'
+	request '' 'GET /file/venise.webp HTTP/1.1' 'Host: localhost'
 	local -r date="$(header Last-Modified)"
 
 	# the header is there but holds no validator, so the date is what decides
-	request '' 'GET /file/venise.webp HTTP/1.0' 'If-None-Match:' "If-Modified-Since: $date"
+	request '' 'GET /file/venise.webp HTTP/1.1' 'Host: localhost' 'If-None-Match:' "If-Modified-Since: $date"
 	[ "$(status_code)" = '304' ]
 	[ -z "$(body)" ]
 }
 
 @test "an If-None-Match of * matches whatever we would have sent" {
-	request '' 'GET /file/venise.webp HTTP/1.0' 'If-None-Match: *'
+	request '' 'GET /file/venise.webp HTTP/1.1' 'Host: localhost' 'If-None-Match: *'
 	[ "$(status_code)" = '304' ]
 	[ -z "$(body)" ]
 }
 
 @test "a POST is never answered with a 304" {
-	request '' 'GET /file/venise.webp HTTP/1.0'
+	request '' 'GET /file/venise.webp HTTP/1.1' 'Host: localhost'
 	local -r etag="$(header ETag)"
 	local -r date="$(header Last-Modified)"
 
 	# conditional requests are defined for GET and HEAD: a 304 here would leave the
 	# client with no representation at all for the body it just sent
-	request '' 'POST /file/venise.webp HTTP/1.0' "If-None-Match: $etag" \
+	request '' 'POST /file/venise.webp HTTP/1.1' 'Host: localhost' "If-None-Match: $etag" \
 		"If-Modified-Since: $date" 'Content-Length: 0'
 	[ "$(status_code)" = '200' ]
 	[ -n "$(body)" ]
 }
 
 @test "a missing file is a 404" {
-	request '' 'GET /file/nope.txt HTTP/1.0'
+	request '' 'GET /file/nope.txt HTTP/1.1' 'Host: localhost'
 	[ "$(status_code)" = '404' ]
 }
 
 @test "a directory is a 404 rather than a listing" {
-	request '' 'GET /file/pages HTTP/1.0'
+	request '' 'GET /file/pages HTTP/1.1' 'Host: localhost'
 	[ "$(status_code)" = '404' ]
-	request '' 'GET /file/ HTTP/1.0'
+	request '' 'GET /file/ HTTP/1.1' 'Host: localhost'
 	[ "$(status_code)" = '404' ]
 }
 
 @test "a script can serve a file from outside its own directory" {
 	# page.sh runs from scripts/, so it reaches the page through ../file/
-	request '' 'GET /page.sh?page=page.html HTTP/1.0'
+	request '' 'GET /page.sh?page=page.html HTTP/1.1' 'Host: localhost'
 	[ "$(status_code)" = '200' ]
 	[ "$(header Content-Type)" = 'text/html; charset=utf-8' ]
 }
 
 @test "page.sh without its parameter is a 404" {
-	request '' 'GET /page.sh HTTP/1.0'
+	request '' 'GET /page.sh HTTP/1.1' 'Host: localhost'
 	[ "$(status_code)" = '404' ]
-	request '' 'GET /page.sh?page= HTTP/1.0'
+	request '' 'GET /page.sh?page= HTTP/1.1' 'Host: localhost'
 	[ "$(status_code)" = '404' ]
 }

--- a/tests/files.bats
+++ b/tests/files.bats
@@ -143,6 +143,120 @@ load 'test_helper'
 	[ -n "$(body)" ]
 }
 
+@test "every file answer announces Accept-Ranges: bytes" {
+	request '' 'GET /file/venise.webp HTTP/1.1' 'Host: localhost'
+	[ "$(status_code)" = '200' ]
+	[ "$(header Accept-Ranges)" = 'bytes' ]
+}
+
+@test "a single byte range is answered with a 206 and the exact bytes" {
+	local -r size="$(stat -c '%s' "$REPO_ROOT/file/venise.webp")"
+	request '' 'GET /file/venise.webp HTTP/1.1' 'Host: localhost' 'Range: bytes=0-3'
+	[ "$(status_code)" = '206' ]
+	[ "$(header Content-Range)" = "bytes 0-3/$size" ]
+	[ "$(header Content-Length)" = '4' ]
+	body > "$BATS_TEST_TMPDIR/served"
+	head -c 4 -- "$REPO_ROOT/file/venise.webp" > "$BATS_TEST_TMPDIR/expected"
+	cmp "$BATS_TEST_TMPDIR/served" "$BATS_TEST_TMPDIR/expected"
+}
+
+@test "an open-ended range runs to the end of the file" {
+	local -r size="$(stat -c '%s' "$REPO_ROOT/file/venise.webp")"
+	request '' 'GET /file/venise.webp HTTP/1.1' 'Host: localhost' 'Range: bytes=4-'
+	[ "$(status_code)" = '206' ]
+	[ "$(header Content-Range)" = "bytes 4-$(( size - 1 ))/$size" ]
+	[ "$(header Content-Length)" = "$(( size - 4 ))" ]
+	body > "$BATS_TEST_TMPDIR/served"
+	tail -c '+5' -- "$REPO_ROOT/file/venise.webp" > "$BATS_TEST_TMPDIR/expected"
+	cmp "$BATS_TEST_TMPDIR/served" "$BATS_TEST_TMPDIR/expected"
+}
+
+@test "a suffix range serves the last N bytes" {
+	local -r size="$(stat -c '%s' "$REPO_ROOT/file/venise.webp")"
+	request '' 'GET /file/venise.webp HTTP/1.1' 'Host: localhost' 'Range: bytes=-4'
+	[ "$(status_code)" = '206' ]
+	[ "$(header Content-Range)" = "bytes $(( size - 4 ))-$(( size - 1 ))/$size" ]
+	[ "$(header Content-Length)" = '4' ]
+	body > "$BATS_TEST_TMPDIR/served"
+	tail -c 4 -- "$REPO_ROOT/file/venise.webp" > "$BATS_TEST_TMPDIR/expected"
+	cmp "$BATS_TEST_TMPDIR/served" "$BATS_TEST_TMPDIR/expected"
+}
+
+@test "a range end past the file is clamped to its size" {
+	local -r size="$(stat -c '%s' "$REPO_ROOT/file/venise.webp")"
+	request '' 'GET /file/venise.webp HTTP/1.1' 'Host: localhost' 'Range: bytes=0-999999999'
+	[ "$(status_code)" = '206' ]
+	[ "$(header Content-Range)" = "bytes 0-$(( size - 1 ))/$size" ]
+	[ "$(header Content-Length)" = "$size" ]
+	body > "$BATS_TEST_TMPDIR/served"
+	cmp "$BATS_TEST_TMPDIR/served" "$REPO_ROOT/file/venise.webp"
+}
+
+@test "a range starting past the end of the file is a 416" {
+	local -r size="$(stat -c '%s' "$REPO_ROOT/file/venise.webp")"
+	request '' 'GET /file/venise.webp HTTP/1.1' 'Host: localhost' 'Range: bytes=999999999-'
+	[ "$(status_code)" = '416' ]
+	# RFC 9110 §15.3.7: the 416 tells the client how big the file actually is
+	[ "$(header Content-Range)" = "bytes */$size" ]
+}
+
+@test "a suffix range of zero bytes is a 416" {
+	local -r size="$(stat -c '%s' "$REPO_ROOT/file/venise.webp")"
+	request '' 'GET /file/venise.webp HTTP/1.1' 'Host: localhost' 'Range: bytes=-0'
+	[ "$(status_code)" = '416' ]
+	[ "$(header Content-Range)" = "bytes */$size" ]
+}
+
+@test "an unparseable or multi-range Range is ignored, never an error" {
+	local -r size="$(stat -c '%s' "$REPO_ROOT/file/venise.webp")"
+	local range
+	while read -r range; do
+		request '' 'GET /file/venise.webp HTTP/1.1' 'Host: localhost' "Range: $range"
+		[ "$(status_code)" = '200' ]
+		[ "$(header Content-Length)" = "$size" ]
+	done <<-'EOF'
+		bytes=0-1,5-9
+		bytes=-
+		bytes=5-2
+		items=0-3
+		bytes=garbage
+		bytes=99999999999999999999-
+	EOF
+}
+
+@test "a stale If-Range disables the range and serves the whole file" {
+	local -r size="$(stat -c '%s' "$REPO_ROOT/file/venise.webp")"
+	request '' 'GET /file/venise.webp HTTP/1.1' 'Host: localhost' 'Range: bytes=0-3' 'If-Range: "0-0"'
+	[ "$(status_code)" = '200' ]
+	[ "$(header Content-Length)" = "$size" ]
+}
+
+@test "an If-Range matching the ETag lets the range through" {
+	request '' 'GET /file/venise.webp HTTP/1.1' 'Host: localhost'
+	local -r etag="$(header ETag)"
+
+	request '' 'GET /file/venise.webp HTTP/1.1' 'Host: localhost' 'Range: bytes=0-3' "If-Range: $etag"
+	[ "$(status_code)" = '206' ]
+	[ "$(header Content-Length)" = '4' ]
+}
+
+@test "a matching If-None-Match wins over a Range" {
+	request '' 'GET /file/venise.webp HTTP/1.1' 'Host: localhost'
+	local -r etag="$(header ETag)"
+
+	request '' 'GET /file/venise.webp HTTP/1.1' 'Host: localhost' 'Range: bytes=0-3' "If-None-Match: $etag"
+	[ "$(status_code)" = '304' ]
+	[ -z "$(body)" ]
+}
+
+@test "a HEAD ignores Range and answers the full-size headers" {
+	local -r size="$(stat -c '%s' "$REPO_ROOT/file/venise.webp")"
+	request '' 'HEAD /file/venise.webp HTTP/1.1' 'Host: localhost' 'Range: bytes=0-3'
+	[ "$(status_code)" = '200' ]
+	[ "$(header Content-Length)" = "$size" ]
+	[ -z "$(body)" ]
+}
+
 @test "a missing file is a 404" {
 	request '' 'GET /file/nope.txt HTTP/1.1' 'Host: localhost'
 	[ "$(status_code)" = '404' ]

--- a/tests/https.bats
+++ b/tests/https.bats
@@ -145,7 +145,7 @@ function teardown_file()
 	# no -k: a MITM that presents its own certificate is what this rejects
 	run curl -s --cacert "$SHERVER_CERT" -i "$SHERVER_URL/"
 	[ "$status" -eq 0 ]
-	[[ "${lines[0]}" == 'HTTP/1.0 200 OK'* ]]
+	[[ "${lines[0]}" == 'HTTP/1.1 200 OK'* ]]
 	[[ "$output" == *'<h1>Sherver example</h1>'* ]]
 }
 

--- a/tests/library.bats
+++ b/tests/library.bats
@@ -23,7 +23,7 @@ load 'test_helper'
 # ------------------------------------------------------------------ parse_url
 
 @test "parse_url splits the base from the query string" {
-	run --separate-stderr with_request 'GET /index.sh?test=youpi&answer=42 HTTP/1.0' \
+	run --separate-stderr with_request $'GET /index.sh?test=youpi&answer=42 HTTP/1.1\nHost: localhost' \
 		'printf "%s\n" "$URL_BASE" "${URL_PARAMETERS[test]}" "${URL_PARAMETERS[answer]}"'
 	[ "$status" -eq 0 ]
 	[ "$output" = '/index.sh
@@ -32,7 +32,7 @@ youpi
 }
 
 @test "parse_url keeps a percent encoded question mark in the path" {
-	run --separate-stderr with_request 'GET /file/what%3F.txt?real=yes HTTP/1.0' \
+	run --separate-stderr with_request $'GET /file/what%3F.txt?real=yes HTTP/1.1\nHost: localhost' \
 		'printf "%s\n" "$URL_BASE" "${URL_PARAMETERS[real]}"'
 	[ "$status" -eq 0 ]
 	[ "$output" = '/file/what?.txt
@@ -40,14 +40,14 @@ yes' ]
 }
 
 @test "parse_url decodes a multibyte character" {
-	run --separate-stderr with_request 'GET /index.sh?city=caf%C3%A9+ville HTTP/1.0' \
+	run --separate-stderr with_request $'GET /index.sh?city=caf%C3%A9+ville HTTP/1.1\nHost: localhost' \
 		'printf "%s\n" "${URL_PARAMETERS[city]}"'
 	[ "$status" -eq 0 ]
 	[ "$output" = 'café ville' ]
 }
 
 @test "parse_url turns + into a space in the query but not in the path" {
-	run --separate-stderr with_request 'GET /a+b.sh?key=a+b HTTP/1.0' \
+	run --separate-stderr with_request $'GET /a+b.sh?key=a+b HTTP/1.1\nHost: localhost' \
 		'printf "%s\n" "$URL_BASE" "${URL_PARAMETERS[key]}"'
 	[ "$status" -eq 0 ]
 	[ "$output" = '/a+b.sh
@@ -56,7 +56,7 @@ a b' ]
 
 @test "parse_url skips a parameter without a name" {
 	# an empty key is a fatal `bad array subscript`, so this must not reach the array
-	run --separate-stderr with_request 'GET /index.sh?=orphan&kept=1 HTTP/1.0' \
+	run --separate-stderr with_request $'GET /index.sh?=orphan&kept=1 HTTP/1.1\nHost: localhost' \
 		'printf "%s\n" "${#URL_PARAMETERS[@]}" "${URL_PARAMETERS[kept]}"'
 	[ "$status" -eq 0 ]
 	[ "$output" = '1
@@ -64,7 +64,7 @@ a b' ]
 }
 
 @test "parse_url leaves a parameter without a value empty" {
-	run --separate-stderr with_request 'GET /index.sh?flag HTTP/1.0' \
+	run --separate-stderr with_request $'GET /index.sh?flag HTTP/1.1\nHost: localhost' \
 		'printf "[%s]\n" "${URL_PARAMETERS[flag]}"'
 	[ "$status" -eq 0 ]
 	[ "$output" = '[]' ]
@@ -73,7 +73,7 @@ a b' ]
 # ------------------------------------------------------- _check_encoding
 
 @test "_check_encoding accepts a properly encoded string" {
-	run --separate-stderr with_request 'GET / HTTP/1.0' \
+	run --separate-stderr with_request $'GET / HTTP/1.1\nHost: localhost' \
 		'for s in "/file/my%20file.txt" "/plain" "100%25"; do
 			_check_encoding "$s" && echo "ok $s" || echo "ko $s"
 		done'
@@ -85,7 +85,7 @@ ok 100%25' ]
 
 @test "_check_encoding rejects what _url_decode cannot decode" {
 	# a NUL truncates the string in bash, the rest is simply not decodable
-	run --separate-stderr with_request 'GET / HTTP/1.0' \
+	run --separate-stderr with_request $'GET / HTTP/1.1\nHost: localhost' \
 		'for s in "%00" "a%00b" "/file/100%" "%zz" "%2" "%g0"; do
 			_check_encoding "$s" && echo "ok $s" || echo "ko $s"
 		done'
@@ -101,7 +101,7 @@ ko %g0' ]
 # ----------------------------------------------------------- _url_decode
 
 @test "_url_decode keeps a backslash literal" {
-	run --separate-stderr with_request 'GET / HTTP/1.0' \
+	run --separate-stderr with_request $'GET / HTTP/1.1\nHost: localhost' \
 		'_url_decode value "back\\slash"; printf "[%s]\n" "$value"'
 	[ "$status" -eq 0 ]
 	[ "$output" = '[back\slash]' ]
@@ -110,7 +110,7 @@ ko %g0' ]
 @test "_url_decode keeps a trailing newline" {
 	# this is why it assigns through printf -v instead of echoing: a command
 	# substitution would drop the newline that %0A decodes to
-	run --separate-stderr with_request 'GET / HTTP/1.0' \
+	run --separate-stderr with_request $'GET / HTTP/1.1\nHost: localhost' \
 		'_url_decode value "line%0A"; printf "%s" "$value" | od -An -c | tr -s " "'
 	[ "$status" -eq 0 ]
 	[ "$output" = ' l i n e \n' ]
@@ -120,7 +120,7 @@ ko %g0' ]
 
 @test "a header value cannot inject a header of its own" {
 	# `printf`, not `echo -e`: the two characters `\r` must stay two characters
-	run --separate-stderr with_request 'GET / HTTP/1.0' \
+	run --separate-stderr with_request $'GET / HTTP/1.1\nHost: localhost' \
 		'add_header "X-Test" "a\r\nEvil: yes"; send_response 200 "body"'
 	[ "$status" -eq 0 ]
 	[[ $output == *'X-Test: a\r\nEvil: yes'* ]]
@@ -130,13 +130,13 @@ ko %g0' ]
 
 @test "send_response counts Content-Length in bytes, not in characters" {
 	# 'café' is 4 characters but 5 bytes, plus the newline printf adds
-	run --separate-stderr with_request 'GET / HTTP/1.0' 'send_response 200 "café"'
+	run --separate-stderr with_request $'GET / HTTP/1.1\nHost: localhost' 'send_response 200 "café"'
 	[ "$status" -eq 0 ]
 	[[ $output == *'Content-Length: 6'* ]]
 }
 
 @test "send_response sends no Content-Length on a 304" {
-	run --separate-stderr with_request 'GET / HTTP/1.0' 'send_response 304'
+	run --separate-stderr with_request $'GET / HTTP/1.1\nHost: localhost' 'send_response 304'
 	[ "$status" -eq 0 ]
 	[[ $output != *'Content-Length'* ]]
 }
@@ -144,54 +144,54 @@ ko %g0' ]
 # ------------------------------------------------------------- send_redirect
 
 @test "send_redirect answers a 302 with the Location and no body" {
-	run --separate-stderr with_request 'GET / HTTP/1.0' 'send_redirect "/index.sh?a=1"'
+	run --separate-stderr with_request $'GET / HTTP/1.1\nHost: localhost' 'send_redirect "/index.sh?a=1"'
 	[ "$status" -eq 0 ]
-	[[ $output == 'HTTP/1.0 302 Found'* ]]
+	[[ $output == 'HTTP/1.1 302 Found'* ]]
 	[[ $output == *'Location: /index.sh?a=1'* ]]
 	[[ $output == *'Content-Length: 0'* ]]
 }
 
 @test "send_redirect sends a 301 when asked to" {
-	run --separate-stderr with_request 'GET / HTTP/1.0' 'send_redirect "/here" 301'
+	run --separate-stderr with_request $'GET / HTTP/1.1\nHost: localhost' 'send_redirect "/here" 301'
 	[ "$status" -eq 0 ]
-	[[ $output == 'HTTP/1.0 301 Moved Permanently'* ]]
+	[[ $output == 'HTTP/1.1 301 Moved Permanently'* ]]
 }
 
 @test "send_redirect refuses a code that is not a redirect" {
 	# an unknown code would kill send_response mid-answer, leaving the client nothing
-	run --separate-stderr with_request 'GET / HTTP/1.0' 'send_redirect "/here" 404'
+	run --separate-stderr with_request $'GET / HTTP/1.1\nHost: localhost' 'send_redirect "/here" 404'
 	[ "$status" -eq 0 ]
-	[[ $output == 'HTTP/1.0 500'* ]]
+	[[ $output == 'HTTP/1.1 500'* ]]
 	[[ $stderr == *'MISCONFIGURED'* ]]
 }
 
 @test "send_redirect without a target is a 500, not a dead connection" {
-	run --separate-stderr with_request 'GET / HTTP/1.0' 'send_redirect'
+	run --separate-stderr with_request $'GET / HTTP/1.1\nHost: localhost' 'send_redirect'
 	[ "$status" -eq 0 ]
-	[[ $output == 'HTTP/1.0 500'* ]]
+	[[ $output == 'HTTP/1.1 500'* ]]
 }
 
 @test "a target holding a CRLF cannot inject a header of its own" {
 	# what '?next=/ok%0d%0aSet-Cookie:+pwn%3D1' decodes to, handed over by a script
-	run --separate-stderr with_request 'GET / HTTP/1.0' \
+	run --separate-stderr with_request $'GET / HTTP/1.1\nHost: localhost' \
 		"send_redirect \$'/ok\r\nSet-Cookie: pwn=1'"
 	[ "$status" -eq 0 ]
-	[[ $output == 'HTTP/1.0 500'* ]]
+	[[ $output == 'HTTP/1.1 500'* ]]
 	[[ $output != *'Set-Cookie'* ]]
 	[[ $stderr == *'MISCONFIGURED'* ]]
 }
 
 @test "a target holding a bare LF is refused too" {
-	run --separate-stderr with_request 'GET / HTTP/1.0' "send_redirect \$'/ok\nEvil: yes'"
+	run --separate-stderr with_request $'GET / HTTP/1.1\nHost: localhost' "send_redirect \$'/ok\nEvil: yes'"
 	[ "$status" -eq 0 ]
-	[[ $output == 'HTTP/1.0 500'* ]]
+	[[ $output == 'HTTP/1.1 500'* ]]
 	[[ $output != *'Evil:'* ]]
 }
 
 # ------------------------------------------------------------- _get_mimetype
 
 @test "_get_mimetype matches the extension whatever its case" {
-	run --separate-stderr with_request 'GET / HTTP/1.0' \
+	run --separate-stderr with_request $'GET / HTTP/1.1\nHost: localhost' \
 		'_get_mimetype "/file/PHOTO.JPG"; _get_mimetype "/file/photo.jpg"'
 	[ "$status" -eq 0 ]
 	[ "$output" = 'image/jpeg
@@ -199,7 +199,7 @@ image/jpeg' ]
 }
 
 @test "_get_mimetype falls back to octet-stream and logs it" {
-	run --separate-stderr with_request 'GET / HTTP/1.0' '_get_mimetype "/file/archive.xyz"'
+	run --separate-stderr with_request $'GET / HTTP/1.1\nHost: localhost' '_get_mimetype "/file/archive.xyz"'
 	[ "$status" -eq 0 ]
 	[ "$output" = 'application/octet-stream' ]
 	[[ $stderr == *'unknown extension'* ]]
@@ -207,7 +207,7 @@ image/jpeg' ]
 
 @test "_get_mimetype ignores a dot that belongs to a parent directory" {
 	# '${path##*.}' alone would read 'd/README' as the extension here
-	run --separate-stderr with_request 'GET / HTTP/1.0' '_get_mimetype "/file/conf.d/README"'
+	run --separate-stderr with_request $'GET / HTTP/1.1\nHost: localhost' '_get_mimetype "/file/conf.d/README"'
 	[ "$status" -eq 0 ]
 	[ "$output" = 'application/octet-stream' ]
 }
@@ -215,7 +215,7 @@ image/jpeg' ]
 # -------------------------------------------------------------- html_escape
 
 @test "html_escape escapes the 5 HTML special characters" {
-	run --separate-stderr with_request 'GET / HTTP/1.0' \
+	run --separate-stderr with_request $'GET / HTTP/1.1\nHost: localhost' \
 		"html_escape '<a href=\"x\">R&D'\''s</a>'"
 	[ "$status" -eq 0 ]
 	[ "$output" = '&lt;a href=&quot;x&quot;&gt;R&amp;D&#39;s&lt;/a&gt;' ]
@@ -224,7 +224,7 @@ image/jpeg' ]
 @test "html_escape does not double escape the entities it just wrote" {
 	# a bare '&' in a replacement is the matched text since bash 5.2, which would
 	# turn '<' into '<lt;' instead of '&lt;'
-	run --separate-stderr with_request 'GET / HTTP/1.0' "html_escape 'a&b<c'"
+	run --separate-stderr with_request $'GET / HTTP/1.1\nHost: localhost' "html_escape 'a&b<c'"
 	[ "$status" -eq 0 ]
 	[ "$output" = 'a&amp;b&lt;c' ]
 }

--- a/tests/lint.sh
+++ b/tests/lint.sh
@@ -218,7 +218,8 @@ function check_tomdoc()
 }
 
 # Internal: `send_error` looks the code up in `HTTP_RESPONSE` under `set -u`, so an
-# unknown one kills the script mid-answer instead of producing an error page.
+# unknown one — sent directly or through `_bail_request` — kills the script mid-answer
+# instead of producing an error page.
 function check_error_codes()
 {
 	local -A known=()
@@ -229,8 +230,8 @@ function check_error_codes()
 	local -a unknown=()
 	while read -r code; do
 		[ -v "known[$code]" ] || unknown+=("$code")
-	done < <(grep -rhoP 'send_error \K[0-9]+' -- "${SOURCE_FILES[@]}" | sort -u)
-	report "sent by send_error but absent from HTTP_RESPONSE:" "${unknown[@]}"
+	done < <(grep -rhoP '(send_error|_bail_request) \K[0-9]+' -- "${SOURCE_FILES[@]}" | sort -u)
+	report "sent by send_error or _bail_request but absent from HTTP_RESPONSE:" "${unknown[@]}"
 }
 
 # Internal: Anything executable under `scripts/` is a reachable HTTP endpoint, so the

--- a/tests/request.bats
+++ b/tests/request.bats
@@ -124,9 +124,18 @@ a b' ]
 	done
 }
 
-@test "extra tokens on the request line are a 400" {
+@test "non-whitespace extra tokens on the request line are a 400" {
 	request '' 'GET / HTTP/1.1 extra' 'Host: localhost'
 	[ "$(status_code)" = '400' ]
+}
+
+@test "whitespace-only extras on the request line are tolerated" {
+	# `read` eats them before the version check ever runs; RFC 9112 §3 grants the leniency
+	local line
+	for line in 'GET / HTTP/1.1 ' 'GET  /  HTTP/1.1' $'GET\t/\tHTTP/1.1'; do
+		request '' "$line" 'Host: localhost'
+		[ "$(status_code)" = '200' ]
+	done
 }
 
 @test "an HTTP major version other than 1 is a 505" {
@@ -135,6 +144,14 @@ a b' ]
 		request '' "GET / $version" 'Host: localhost'
 		[ "$(status_code)" = '505' ]
 	done
+}
+
+@test "an HTTP 1.x minor above 1 is served as 1.1, Host gate included" {
+	# RFC 9112 §2.3: process it as the highest minor version we conform to
+	request '' 'GET / HTTP/1.9' 'Host: localhost'
+	[ "$(status_code)" = '200' ]
+	request '' 'GET / HTTP/1.9'
+	[ "$(status_code)" = '400' ]
 }
 
 @test "a header line without a name is a 400, not a crash" {

--- a/tests/request.bats
+++ b/tests/request.bats
@@ -112,6 +112,16 @@ a b' ]
 	done
 }
 
+@test "a method that is not a token is a 400, not a 501" {
+	# RFC 9112 §3: a stray octet in the method is a malformed request line, not an unknown
+	# method. The comma-glued ones would even span entries of the supported-methods list
+	local method
+	for method in GET,HEAD HEAD,POST 'GE(T' 'GET;' '"GET"'; do
+		request '' "$method / HTTP/1.1" 'Host: localhost'
+		[ "$(status_code)" = '400' ]
+	done
+}
+
 @test "a script answers its own 405 with Allow" {
 	request '' 'DELETE /page.sh?page=page.html HTTP/1.1' 'Host: localhost'
 	[ "$(status_code)" = '405' ]
@@ -201,7 +211,9 @@ authority.example' ]
 	# RFC 9110 §4.2: an http(s) URI with an empty host is invalid and userinfo is an
 	# error, and the authority must be decodable like everything else client-sent
 	local target
+	# `:8080` and `:` are an empty host too, and would land in `Host` and skip its 400
 	for target in 'http://' 'http:///index.sh' 'http://user:pass@example.com/index.sh' \
+		'http://:8080/index.sh' 'http://:/index.sh' \
 		'http://a%00b/index.sh' 'http://100%/index.sh'; do
 		request '' "GET $target HTTP/1.1" 'Host: localhost'
 		[ "$(status_code)" = '400' ]
@@ -333,6 +345,16 @@ authority.example' ]
 	[ "$(status_code)" = '413' ]
 }
 
+@test "a Content-Length is measured on its value, not its padding" {
+	# `1*DIGIT` allows leading zeros, which say nothing about magnitude
+	request 'hello there' 'POST / HTTP/1.1' 'Host: localhost' 'Content-Length: 00000000011'
+	[ "$(status_code)" = '200' ]
+	[[ "$(body)" == *"You just sent me 'hello there'!"* ]]
+	# and padding must not smuggle a huge value past the digit cap either
+	request '' 'POST / HTTP/1.1' 'Host: localhost' 'Content-Length: 000000000099999999999'
+	[ "$(status_code)" = '413' ]
+}
+
 # ------------------------------------------------------------------- headers
 
 @test "header names are matched case insensitively" {
@@ -351,7 +373,17 @@ X-MiXeD-CaSe: yes' \
 	[ "$(header Connection)" = 'close' ]
 	[ "$(header X-Content-Type-Options)" = 'nosniff' ]
 	[ -n "$(header Date)" ]
-	[ -n "$(header Expires)" ]
+	# no `Expires`: a cache ignores it whenever `max-age` is there (RFC 9111 §5.3), so it
+	# could only ever contradict the `Cache-Control` above
+	[[ "$(header_names)" != *expires* ]]
+}
+
+@test "an error page is never stored" {
+	# several codes depend on a request header nothing nominates in a `Vary` (Range, the
+	# header-size limits, the version), so a stored error page could answer a good request
+	request '' 'GET /file/nope.txt HTTP/1.1' 'Host: localhost'
+	[ "$(status_code)" = '404' ]
+	[ "$(header Cache-Control)" = 'no-store' ]
 }
 
 @test "the status line is HTTP 1.1 even to an HTTP 1.0 client" {

--- a/tests/request.bats
+++ b/tests/request.bats
@@ -28,32 +28,32 @@ function filler()
 # ------------------------------------------------------------------- routing
 
 @test "GET / serves the index" {
-	request '' 'GET / HTTP/1.0'
+	request '' 'GET / HTTP/1.1' 'Host: localhost'
 	[ "$(status_code)" = '200' ]
 	[ "$(header Content-Type)" = 'text/html; charset=utf-8' ]
 	[[ "$(body)" == *'<h1>Sherver example</h1>'* ]]
 }
 
 @test "GET /index.html and /index.htm reach the same script" {
-	request '' 'GET /index.html HTTP/1.0'
+	request '' 'GET /index.html HTTP/1.1' 'Host: localhost'
 	[ "$(status_code)" = '200' ]
-	request '' 'GET /index.htm HTTP/1.0'
+	request '' 'GET /index.htm HTTP/1.1' 'Host: localhost'
 	[ "$(status_code)" = '200' ]
 }
 
 @test "GET of an unknown script is a 404" {
-	request '' 'GET /nope.sh HTTP/1.0'
+	request '' 'GET /nope.sh HTTP/1.1' 'Host: localhost'
 	[ "$(status_code)" = '404' ]
 }
 
 @test "the library itself is not a reachable endpoint" {
 	# it is not executable, so run_script refuses it rather than running it
-	request '' 'GET /SHERVER_UTILS.sh HTTP/1.0'
+	request '' 'GET /SHERVER_UTILS.sh HTTP/1.1' 'Host: localhost'
 	[ "$(status_code)" = '404' ]
 }
 
 @test "the query string reaches the script" {
-	request '' 'GET /index.sh?test=youpi&answer=42 HTTP/1.0'
+	request '' 'GET /index.sh?test=youpi&answer=42 HTTP/1.1' 'Host: localhost'
 	[ "$(status_code)" = '200' ]
 	[[ "$(body)" == *'test: youpi'* ]]
 	[[ "$(body)" == *'answer: 42'* ]]
@@ -62,10 +62,10 @@ function filler()
 # -------------------------------------------------------------------- methods
 
 @test "HEAD sends the headers of the GET and no body" {
-	request '' 'GET / HTTP/1.0'
+	request '' 'GET / HTTP/1.1' 'Host: localhost'
 	local -r get_names="$(header_names)"
 
-	request '' 'HEAD / HTTP/1.0'
+	request '' 'HEAD / HTTP/1.1' 'Host: localhost'
 	[ "$(status_code)" = '200' ]
 	[ -z "$(body)" ]
 	[ "$(header_names)" = "$get_names" ]
@@ -75,14 +75,15 @@ function filler()
 }
 
 @test "POST hands the body to the script" {
-	request 'hello there' 'POST / HTTP/1.0' 'Content-Length: 11'
+	request 'hello there' 'POST / HTTP/1.1' 'Host: localhost' 'Content-Length: 11'
 	[ "$(status_code)" = '200' ]
 	[[ "$(body)" == *"You just sent me 'hello there'!"* ]]
 }
 
 @test "POST parses an urlencoded body, charset parameter and all" {
 	run --separate-stderr with_request \
-		'POST / HTTP/1.0
+		'POST / HTTP/1.1
+Host: localhost
 Content-Type: application/x-www-form-urlencoded; charset=UTF-8
 Content-Length: 21
 
@@ -96,7 +97,7 @@ a b' ]
 @test "an unsupported method is a 405" {
 	local method
 	for method in PUT DELETE OPTIONS PATCH TRACE; do
-		request '' "$method / HTTP/1.0"
+		request '' "$method / HTTP/1.1" 'Host: localhost'
 		[ "$(status_code)" = '405' ]
 	done
 }
@@ -118,7 +119,7 @@ a b' ]
 @test "a header line without a name is a 400, not a crash" {
 	local header
 	for header in ': naughty' ':naughty' $'\t: naughty'; do
-		request '' 'GET / HTTP/1.0' "$header"
+		request '' 'GET / HTTP/1.1' 'Host: localhost' "$header"
 		[ "$(status_code)" = '400' ]
 	done
 }
@@ -126,42 +127,42 @@ a b' ]
 @test "a URL that is not decodable is a 400" {
 	local url
 	for url in '/index.sh?a=%zz' '/%2' '/file/100%' '/index.sh?a=%00'; do
-		request '' "GET $url HTTP/1.0"
+		request '' "GET $url HTTP/1.1" 'Host: localhost'
 		[ "$(status_code)" = '400' ]
 	done
 }
 
 @test "a Content-Length that is not a number is a 400" {
-	request 'body' 'POST / HTTP/1.0' 'Content-Length: abc'
+	request 'body' 'POST / HTTP/1.1' 'Host: localhost' 'Content-Length: abc'
 	[ "$(status_code)" = '400' ]
 }
 
 @test "a body shorter than Content-Length is a 400" {
-	request 'short' 'POST / HTTP/1.0' 'Content-Length: 999'
+	request 'short' 'POST / HTTP/1.1' 'Host: localhost' 'Content-Length: 999'
 	[ "$(status_code)" = '400' ]
 }
 
 # --------------------------------------------------------------- size limits
 
 @test "a request line over 8 kio is a 414" {
-	request '' "GET /$(filler 8200) HTTP/1.0"
+	request '' "GET /$(filler 8200) HTTP/1.1" 'Host: localhost'
 	[ "$(status_code)" = '414' ]
 }
 
 @test "headers over 8 kio are a 431" {
-	request '' 'GET / HTTP/1.0' "X-Long: $(filler 8200)"
+	request '' 'GET / HTTP/1.1' 'Host: localhost' "X-Long: $(filler 8200)"
 	[ "$(status_code)" = '431' ]
 }
 
 @test "a body over 64 kio is a 413" {
 	# refused on the announced length, so there is no need to send the bytes
-	request '' 'POST / HTTP/1.0' 'Content-Length: 65537'
+	request '' 'POST / HTTP/1.1' 'Host: localhost' 'Content-Length: 65537'
 	[ "$(status_code)" = '413' ]
 }
 
 @test "a Content-Length too big for the shell is a 413, not a crash" {
 	# outside test's integer range `-gt` errors out, which would skip the limit
-	request '' 'POST / HTTP/1.0' 'Content-Length: 99999999999999999999999'
+	request '' 'POST / HTTP/1.1' 'Host: localhost' 'Content-Length: 99999999999999999999999'
 	[ "$(status_code)" = '413' ]
 }
 
@@ -169,7 +170,8 @@ a b' ]
 
 @test "header names are matched case insensitively" {
 	run --separate-stderr with_request \
-		'GET / HTTP/1.0
+		'GET / HTTP/1.1
+Host: localhost
 X-MiXeD-CaSe: yes' \
 		'printf "%s\n" "${REQUEST_HEADERS[x-mixed-case]}"'
 	[ "$status" -eq 0 ]
@@ -177,7 +179,7 @@ X-MiXeD-CaSe: yes' \
 }
 
 @test "every response carries the default headers" {
-	request '' 'GET / HTTP/1.0'
+	request '' 'GET / HTTP/1.1' 'Host: localhost'
 	[ "$(header Server)" = 'Sherver' ]
 	[ "$(header Connection)" = 'close' ]
 	[ "$(header X-Content-Type-Options)" = 'nosniff' ]
@@ -185,32 +187,34 @@ X-MiXeD-CaSe: yes' \
 	[ -n "$(header Expires)" ]
 }
 
-@test "the status line is HTTP 1.0 whatever the client announced" {
-	request '' 'GET / HTTP/1.1'
-	[ "$(status_line)" = 'HTTP/1.0 200 OK' ]
+@test "the status line is HTTP 1.1 even to an HTTP 1.0 client" {
+	# the version advertises capability (RFC 9112 §2.3), it does not echo the request.
+	# Deliberately no Host header either: it is the HTTP 1.0 compatibility fixture
+	request '' 'GET / HTTP/1.0'
+	[ "$(status_line)" = 'HTTP/1.1 200 OK' ]
 }
 
 @test "an error page announces its own length" {
-	request '' 'GET /nope.sh HTTP/1.0'
+	request '' 'GET /nope.sh HTTP/1.1' 'Host: localhost'
 	[ "$(header Content-Length)" = "$(body | wc -c)" ]
 }
 
 # ------------------------------------------------------------------- logging
 
 @test "a served request logs exactly one access line" {
-	request '' 'GET /index.sh?a=1 HTTP/1.0'
+	request '' 'GET /index.sh?a=1 HTTP/1.1' 'Host: localhost'
 	# the address is socat's; driven as a filter there is none, hence the `-`
 	[ "$(log_output)" = '- GET /index.sh?a=1 200' ]
 }
 
 @test "an error logs its reason next to the access line" {
-	request '' 'GET /nope.sh HTTP/1.0'
+	request '' 'GET /nope.sh HTTP/1.1' 'Host: localhost'
 	[[ "$(log_output)" == *'NOT FOUND'* ]]
 	[[ "$(log_output)" == *'- GET /nope.sh 404'* ]]
 }
 
 @test "index.sh escapes what the client sent instead of reflecting it" {
-	request '' 'GET /index.sh?%3Cscript%3E=%3Cimg+onerror%3Dalert(1)%3E HTTP/1.0' \
+	request '' 'GET /index.sh?%3Cscript%3E=%3Cimg+onerror%3Dalert(1)%3E HTTP/1.1' 'Host: localhost' \
 		'X-Evil: <script>alert(2)</script>'
 	[ "$(status_code)" = '200' ]
 	# nothing the client wrote may come back as markup

--- a/tests/request.bats
+++ b/tests/request.bats
@@ -94,11 +94,49 @@ name=r%C3%A9mi&up=a+b' \
 a b' ]
 }
 
-@test "an unsupported method is a 405" {
+@test "a known but unsupported method is a 405 carrying Allow" {
 	local method
-	for method in PUT DELETE OPTIONS PATCH TRACE; do
+	for method in PUT DELETE PATCH TRACE CONNECT; do
 		request '' "$method / HTTP/1.1" 'Host: localhost'
 		[ "$(status_code)" = '405' ]
+		[ "$(header Allow)" = 'GET, HEAD, POST, OPTIONS' ]
+	done
+}
+
+@test "an unknown method is a 501" {
+	local method
+	# `get` included: method names are case sensitive, so it is not a GET
+	for method in BREW FOO get; do
+		request '' "$method / HTTP/1.1" 'Host: localhost'
+		[ "$(status_code)" = '501' ]
+	done
+}
+
+@test "a script answers its own 405 with Allow" {
+	request '' 'DELETE /page.sh?page=page.html HTTP/1.1' 'Host: localhost'
+	[ "$(status_code)" = '405' ]
+	# the dispatcher never reaches the script for DELETE, so this is the library's list
+	[ "$(header Allow)" = 'GET, HEAD, POST, OPTIONS' ]
+	request '' 'POST /page.sh?page=page.html HTTP/1.1' 'Host: localhost' 'Content-Length: 0'
+	[ "$(status_code)" = '405' ]
+	[ "$(header Allow)" = 'GET, HEAD, OPTIONS' ]
+}
+
+@test "OPTIONS is answered server wide with Allow and an empty body" {
+	request '' 'OPTIONS / HTTP/1.1' 'Host: localhost'
+	[ "$(status_code)" = '200' ]
+	[ "$(header Allow)" = 'GET, HEAD, POST, OPTIONS' ]
+	[ "$(header Content-Length)" = '0' ]
+	[ -z "$(body)" ]
+}
+
+@test "OPTIONS answers before any routing" {
+	# asterisk form (RFC 9112 §3.2.4), and a path that would otherwise be a 404
+	local target
+	for target in '*' '/nope.sh' '/file/nope.txt'; do
+		request '' "OPTIONS $target HTTP/1.1" 'Host: localhost'
+		[ "$(status_code)" = '200' ]
+		[ "$(header Allow)" = 'GET, HEAD, POST, OPTIONS' ]
 	done
 }
 

--- a/tests/request.bats
+++ b/tests/request.bats
@@ -116,6 +116,27 @@ a b' ]
 	[ "$(status_code)" = '400' ]
 }
 
+@test "a version that is not HTTP/major.minor is a 400" {
+	local version
+	for version in 'HTP/1.1' 'HTTP/1.1garbage' 'HTTP/11' 'http/1.1'; do
+		request '' "GET / $version" 'Host: localhost'
+		[ "$(status_code)" = '400' ]
+	done
+}
+
+@test "extra tokens on the request line are a 400" {
+	request '' 'GET / HTTP/1.1 extra' 'Host: localhost'
+	[ "$(status_code)" = '400' ]
+}
+
+@test "an HTTP major version other than 1 is a 505" {
+	local version
+	for version in 'HTTP/2.0' 'HTTP/0.9'; do
+		request '' "GET / $version" 'Host: localhost'
+		[ "$(status_code)" = '505' ]
+	done
+}
+
 @test "a header line without a name is a 400, not a crash" {
 	local header
 	for header in ': naughty' ':naughty' $'\t: naughty'; do

--- a/tests/request.bats
+++ b/tests/request.bats
@@ -145,6 +145,12 @@ a b' ]
 	done
 }
 
+@test "an HTTP 1.1 request without a Host header is a 400" {
+	# RFC 9112 §3.2. The HTTP 1.0 fixture below proves 1.0 stays exempt
+	request '' 'GET / HTTP/1.1'
+	[ "$(status_code)" = '400' ]
+}
+
 @test "a URL that is not decodable is a 400" {
 	local url
 	for url in '/index.sh?a=%zz' '/%2' '/file/100%' '/index.sh?a=%00'; do
@@ -213,6 +219,13 @@ X-MiXeD-CaSe: yes' \
 	# Deliberately no Host header either: it is the HTTP 1.0 compatibility fixture
 	request '' 'GET / HTTP/1.0'
 	[ "$(status_line)" = 'HTTP/1.1 200 OK' ]
+}
+
+@test "the Host header survives the child script re-parse" {
+	# index.sh re-parses REQUEST_FULL_STRING in its own process: the Host line must
+	# round-trip through it, or every scripted endpoint would 400 on the second parse
+	request '' 'GET /index.sh HTTP/1.1' 'Host: localhost'
+	[ "$(status_code)" = '200' ]
 }
 
 @test "an error page announces its own length" {

--- a/tests/request.bats
+++ b/tests/request.bats
@@ -140,6 +140,91 @@ a b' ]
 	done
 }
 
+# --------------------------------------------------------- absolute-form URL
+
+@test "an absolute-form target is served as its path" {
+	# RFC 9112 §3.2.2, what a proxy sends. The scheme is case insensitive, the path is not
+	local target
+	for target in 'http://example.com/index.sh?test=youpi' \
+		'HTTPS://Example.COM/index.sh?test=youpi' \
+		'http://example.com:8080/index.sh?test=youpi'; do
+		request '' "GET $target HTTP/1.1" 'Host: localhost'
+		[ "$(status_code)" = '200' ]
+		[[ "$(body)" == *'test: youpi'* ]]
+	done
+}
+
+@test "an absolute-form target with no path is the root" {
+	local target
+	for target in 'http://example.com' 'http://example.com/'; do
+		request '' "GET $target HTTP/1.1" 'Host: localhost'
+		[ "$(status_code)" = '200' ]
+		[[ "$(body)" == *'<h1>Sherver example</h1>'* ]]
+	done
+}
+
+@test "a query string survives a target that has no path" {
+	# the authority stops at the `?` as well, so the query is not swallowed with it
+	request '' 'GET http://example.com?test=youpi HTTP/1.1' 'Host: localhost'
+	[ "$(status_code)" = '200' ]
+	[[ "$(body)" == *'test: youpi'* ]]
+}
+
+@test "an absolute-form target satisfies the Host requirement on its own" {
+	# its authority is the host, so a 1.1 request needs no Host header
+	request '' 'GET http://example.com/ HTTP/1.1'
+	[ "$(status_code)" = '200' ]
+}
+
+@test "the authority of an absolute-form target overrides the Host header" {
+	# RFC 9112 §3.2.2 makes it a MUST, whichever order the client sends them in
+	run --separate-stderr with_request \
+		'GET http://authority.example/index.sh HTTP/1.1
+Host: header.example' \
+		'printf "%s\n" "$REQUEST_URL" "${REQUEST_HEADERS[host]}"'
+	[ "$status" -eq 0 ]
+	[ "$output" = '/index.sh
+authority.example' ]
+}
+
+@test "a fragment on an absolute-form target is dropped, not glued onto the path" {
+	# a request-target carries no fragment (RFC 9112 §3.2), wherever the client put one
+	request '' 'GET http://example.com/index.sh?test=youpi#frag HTTP/1.1' 'Host: localhost'
+	[ "$(status_code)" = '200' ]
+	[[ "$(body)" == *'test: youpi'* ]]
+	request '' 'GET http://example.com#frag HTTP/1.1' 'Host: localhost'
+	[ "$(status_code)" = '200' ]
+	[[ "$(body)" == *'<h1>Sherver example</h1>'* ]]
+}
+
+@test "an absolute-form target with an invalid authority is a 400" {
+	# RFC 9110 §4.2: an http(s) URI with an empty host is invalid and userinfo is an
+	# error, and the authority must be decodable like everything else client-sent
+	local target
+	for target in 'http://' 'http:///index.sh' 'http://user:pass@example.com/index.sh' \
+		'http://a%00b/index.sh' 'http://100%/index.sh'; do
+		request '' "GET $target HTTP/1.1" 'Host: localhost'
+		[ "$(status_code)" = '400' ]
+	done
+}
+
+@test "a target that is neither a path nor a form we rewrite is a 400" {
+	# RFC 9112 §3.2: origin, absolute (http/https here) and asterisk forms are all there
+	# is — and the asterisk one belongs to OPTIONS alone
+	local target
+	for target in 'ftp://example.com/x' 'Zindex.sh' '*'; do
+		request '' "GET $target HTTP/1.1" 'Host: localhost'
+		[ "$(status_code)" = '400' ]
+	done
+}
+
+@test "the access log shows an absolute-form target as the client sent it" {
+	# the rewrite must not hide proxy-style requests from whoever greps the log
+	request '' 'GET http://example.com/index.sh HTTP/1.1' 'Host: localhost'
+	[ "$(status_code)" = '200' ]
+	[[ "$(log_output)" == *'GET http://example.com/index.sh 200'* ]]
+}
+
 # ------------------------------------------------------------ malformed input
 
 @test "an empty request is a 400" {

--- a/tests/server.bats
+++ b/tests/server.bats
@@ -71,7 +71,7 @@ function teardown_file()
 @test "a real client is answered" {
 	run curl -ks -i "$SHERVER_URL/"
 	[ "$status" -eq 0 ]
-	[[ "${lines[0]}" == 'HTTP/1.0 200 OK'* ]]
+	[[ "${lines[0]}" == 'HTTP/1.1 200 OK'* ]]
 	[[ "$output" == *'<h1>Sherver example</h1>'* ]]
 }
 

--- a/tests/test_helper.bash
+++ b/tests/test_helper.bash
@@ -45,7 +45,7 @@ declare -g RESPONSE_LOG=''
 #
 # Examples
 #
-#    request_raw $'GET / HTTP/1.0\r\n\r\n'
+#    request_raw $'GET / HTTP/1.1\r\nHost: localhost\r\n\r\n'
 function request_raw()
 {
 	RESPONSE="$BATS_TEST_TMPDIR/response"
@@ -64,8 +64,8 @@ function request_raw()
 #
 # Examples
 #
-#    request '' 'GET /index.sh?a=1 HTTP/1.0' 'Host: localhost'
-#    request 'a=1&b=2' 'POST / HTTP/1.0' 'Content-Length: 7'
+#    request '' 'GET /index.sh?a=1 HTTP/1.1' 'Host: localhost'
+#    request 'a=1&b=2' 'POST / HTTP/1.1' 'Host: localhost' 'Content-Length: 7'
 function request()
 {
 	local -r body="$1"
@@ -153,7 +153,7 @@ function log_output()
 #
 # Examples
 #
-#    run --separate-stderr with_request 'GET /index.sh?a=b HTTP/1.0' 'echo "$URL_BASE"'
+#    run --separate-stderr with_request $'GET /index.sh?a=b HTTP/1.1\nHost: localhost' 'echo "$URL_BASE"'
 function with_request()
 {
 	( cd -- "$REPO_ROOT" && bash -c "source '$LIBRARY'; init_environment; $2" ) <<< "$1"


### PR DESCRIPTION
The goal is to by at least partially compatible with HTTP/1.1 to be able to reply with header that indicates this version of HTTP instead of 1.0.

steps:

- [x] status line says `HTTP/1.1`
- [x] request-line version validation + 505
- [x] Host header enforcement
- [x] methods: 501, `Allow` on 405, OPTIONS
- [x] absolute-form request-target
- [x] Range requests: video streaming and seeking
- [x] release polish